### PR TITLE
fix/ar map crash

### DIFF
--- a/app/(site)/ar/maps/page.tsx
+++ b/app/(site)/ar/maps/page.tsx
@@ -1,30 +1,21 @@
-// app/(site)/ar/page.tsx
-export default function PageAr() {
+// app/(site)/ar/maps/page.tsx
+import dynamic from 'next/dynamic';
+
+export const metadata = {
+  title: 'الخريطة',
+  description: 'أماكن فلسطين — عرض تفاعلي.',
+  alternates: { languages: { en: '/maps' } },
+} as const;
+
+// Client-only Leaflet map
+const MapClient = dynamic(() => import('@/components/MapClient'), { ssr: false });
+
+export default function Page() {
   return (
-    <main className="mx-auto max-w-3xl px-4 py-12" dir="rtl" lang="ar">
-      <h1 className="text-3xl font-semibold tracking-tight">فلسطين</h1>
-      <p className="mt-2 text-base text-gray-700">
-        هذا هو المسار العربي للمشروع — تاريخ عام وفني لفلسطين عبر ٤٠٠٠ سنة، يركز على الذاكرة
-        المناهضة للاستعمار والمصادر والشهادات الفلسطينية.
-      </p>
-
-      <section className="mt-6 space-y-3">
-        <div className="space-x-0 space-y-2 sm:space-y-0 sm:space-x-3 sm:[&>*]:inline-block">
-          <a href="/ar/maps" className="rounded border px-3 py-2 text-sm hover:bg-gray-50">
-            عرض الأماكن على الخريطة
-          </a>
-          <a href="/ar/chapters/001-prologue" className="rounded border px-3 py-2 text-sm hover:bg-gray-50">
-            قراءة المقدّمة
-          </a>
-        </div>
-      </section>
-
-      {/* Language toggle */}
-      <p className="mt-10 text-sm text-gray-600">
-        <a className="underline hover:no-underline" href="/">
-          ← English
-        </a>
-      </p>
+    <main className="min-h-screen">
+      <div className="h-[80vh]">
+        <MapClient />
+      </div>
     </main>
   );
 }

--- a/app/(site)/ar/maps/page.tsx
+++ b/app/(site)/ar/maps/page.tsx
@@ -1,21 +1,39 @@
 // app/(site)/ar/maps/page.tsx
-import dynamic from 'next/dynamic';
+import { loadGazetteer } from '@/lib/loaders.places';
+import { loadMapConfig } from '@/lib/loaders.config';
+import MapsPageClientAr from '@/components/MapsPageClient.ar';
 
 export const metadata = {
-  title: 'الخريطة',
-  description: 'أماكن فلسطين — عرض تفاعلي.',
+  title: 'الأماكن',
+  description: 'خريطة تفاعلية للأماكن الفلسطينية.',
   alternates: { languages: { en: '/maps' } },
 } as const;
 
-// Client-only Leaflet map
-const MapClient = dynamic(() => import('@/components/MapClient'), { ssr: false });
+export default function MapsPageAr({
+  searchParams,
+}: {
+  searchParams?: { place?: string };
+}) {
+  const places = loadGazetteer();
+  const cfg = loadMapConfig();
+  const initialFocusId = searchParams?.place;
 
-export default function Page() {
+  const enHref = initialFocusId ? `/maps?place=${initialFocusId}` : '/maps';
+
   return (
-    <main className="min-h-screen">
-      <div className="h-[80vh]">
-        <MapClient />
-      </div>
+    <main className="mx-auto max-w-3xl px-4 py-12" dir="rtl" lang="ar">
+      <h1 className="text-2xl font-semibold tracking-tight font-arabic">الأماكن</h1>
+      <p className="mt-2 text-sm text-gray-600 font-arabic">
+        محمّلة من <code>data/gazetteer.json</code>
+      </p>
+
+      <MapsPageClientAr places={places} cfg={cfg} initialFocusId={initialFocusId} />
+
+      <p className="mt-8 text-sm text-gray-600">
+        <a className="underline hover:no-underline" href={enHref}>
+          ← English
+        </a>
+      </p>
     </main>
   );
 }


### PR DESCRIPTION
- **fix(maps-ar): client-only render and stable container height; clean metadata typing**
- **fix(ar/maps): pass gazetteer + cfg via MapsPageClientAr; add EN alternate and RTL**
- **fix(timeline): coerce era start/end to numbers to satisfy Era types**
- **fix(timeline): parse start/end as numeric years to satisfy Era/TimelineEvent types**
