### PR TITLE
fix/home hydration search

### DIFF
--- a/app/(site)/ar/maps/page.tsx
+++ b/app/(site)/ar/maps/page.tsx
@@ -1,39 +1,68 @@
-// app/(site)/ar/maps/page.tsx
-import { loadGazetteer } from '@/lib/loaders.places';
-import { loadMapConfig } from '@/lib/loaders.config';
-import MapsPageClientAr from '@/components/MapsPageClient.ar';
+// app/(site)/page.tsx
+import dynamic from 'next/dynamic';
+import { loadSearchDocs } from '@/lib/loaders.search';
 
 export const metadata = {
-  title: 'الأماكن',
-  description: 'خريطة تفاعلية للأماكن الفلسطينية.',
-  alternates: { languages: { en: '/maps' } },
+  title: 'Palestine',
+  description:
+    'A public, art-grade digital history spanning 4,000 years — centering Palestinian life, sources, and anti-colonial memory.',
+  alternates: { languages: { ar: '/ar' } },
 } as const;
 
-export default function MapsPageAr({
-  searchParams,
-}: {
-  searchParams?: { place?: string };
-}) {
-  const places = loadGazetteer();
-  const cfg = loadMapConfig();
-  const initialFocusId = searchParams?.place;
+// Client-only Search to avoid SSR/client ordering mismatches
+const Search = dynamic(() => import('@/components/Search'), { ssr: false });
 
-  const enHref = initialFocusId ? `/maps?place=${initialFocusId}` : '/maps';
+export default function Page() {
+  const docs = loadSearchDocs();
 
   return (
-    <main className="mx-auto max-w-3xl px-4 py-12" dir="rtl" lang="ar">
-      <h1 className="text-2xl font-semibold tracking-tight font-arabic">الأماكن</h1>
-      <p className="mt-2 text-sm text-gray-600 font-arabic">
-        محمّلة من <code>data/gazetteer.json</code>
-      </p>
+    <main className="mx-auto max-w-3xl px-4 py-12">
+      <header className="mb-8">
+        <h1 className="text-3xl font-semibold tracking-tight">Palestine</h1>
+        <p className="mt-2 text-base text-gray-600">
+          A public, art-grade digital history spanning 4,000 years — centering Palestinian life,
+          sources, and anti-colonial memory.
+        </p>
+      </header>
 
-      <MapsPageClientAr places={places} cfg={cfg} initialFocusId={initialFocusId} />
+      <div className="mb-6">
+        <Search docs={docs} />
+      </div>
 
-      <p className="mt-8 text-sm text-gray-600">
-        <a className="underline hover:no-underline" href={enHref}>
-          ← English
+      <section className="space-y-4">
+        <div className="space-x-3">
+          <a href="/timeline" className="inline-block rounded border px-3 py-2 text-sm hover:bg-gray-50">
+            Explore the timeline
+          </a>
+          <a href="/maps" className="inline-block rounded border px-3 py-2 text-sm hover:bg-gray-50">
+            View places on the map
+          </a>
+        </div>
+
+        <div className="mt-6">
+          <h2 className="text-sm font-semibold text-gray-700">Featured chapters</h2>
+          <ul className="mt-2 list-disc pl-5 text-sm">
+            <li>
+              <a className="underline hover:no-underline" href="/chapters/001-prologue">
+                Prologue — On Names, Memory, and Return
+              </a>
+            </li>
+            <li>
+              <a className="underline hover:no-underline" href="/chapters/002-foundations-canaanite-networks">
+                Foundations — Canaanite Urban Networks (-2000 to -1200)
+              </a>
+            </li>
+          </ul>
+        </div>
+      </section>
+
+      <p className="mt-10 text-sm text-gray-600">
+        <a className="underline hover:no-underline" href="/ar">
+          View this site in Arabic →
         </a>
       </p>
+
+      <footer className="mt-12 text-xs text-gray-500">Code: MIT · Content: CC BY-SA 4.0</footer>
     </main>
   );
 }

--- a/app/(site)/ar/maps/page.tsx
+++ b/app/(site)/ar/maps/page.tsx
@@ -1,68 +1,37 @@
-// app/(site)/page.tsx
-import dynamic from 'next/dynamic';
-import { loadSearchDocs } from '@/lib/loaders.search';
+// app/(site)/ar/maps/page.tsx
+import { loadGazetteer } from '@/lib/loaders.places';
+import { loadMapConfig } from '@/lib/loaders.config';
+import MapsPageClientAr from '@/components/MapsPageClient.ar';
 
 export const metadata = {
-  title: 'Palestine',
-  description:
-    'A public, art-grade digital history spanning 4,000 years — centering Palestinian life, sources, and anti-colonial memory.',
-  alternates: { languages: { ar: '/ar' } },
+  title: 'الأماكن',
+  description: 'خريطة تفاعلية للأماكن الفلسطينية.',
+  alternates: { languages: { en: '/maps' } },
 } as const;
 
-// Client-only Search to avoid SSR/client ordering mismatches
-const Search = dynamic(() => import('@/components/Search'), { ssr: false });
-
-export default function Page() {
-  const docs = loadSearchDocs();
+export default function MapsPageAr({
+  searchParams,
+}: {
+  searchParams?: { place?: string };
+}) {
+  const places = loadGazetteer();
+  const cfg = loadMapConfig();
+  const initialFocusId = searchParams?.place;
+  const enHref = initialFocusId ? `/maps?place=${initialFocusId}` : '/maps';
 
   return (
-    <main className="mx-auto max-w-3xl px-4 py-12">
-      <header className="mb-8">
-        <h1 className="text-3xl font-semibold tracking-tight">Palestine</h1>
-        <p className="mt-2 text-base text-gray-600">
-          A public, art-grade digital history spanning 4,000 years — centering Palestinian life,
-          sources, and anti-colonial memory.
-        </p>
-      </header>
+    <main className="mx-auto max-w-3xl px-4 py-12" dir="rtl" lang="ar">
+      <h1 className="text-2xl font-semibold tracking-tight font-arabic">الأماكن</h1>
 
-      <div className="mb-6">
-        <Search docs={docs} />
+      <div className="mt-4">
+        <MapsPageClientAr places={places} cfg={cfg} initialFocusId={initialFocusId} />
       </div>
 
-      <section className="space-y-4">
-        <div className="space-x-3">
-          <a href="/timeline" className="inline-block rounded border px-3 py-2 text-sm hover:bg-gray-50">
-            Explore the timeline
-          </a>
-          <a href="/maps" className="inline-block rounded border px-3 py-2 text-sm hover:bg-gray-50">
-            View places on the map
-          </a>
-        </div>
-
-        <div className="mt-6">
-          <h2 className="text-sm font-semibold text-gray-700">Featured chapters</h2>
-          <ul className="mt-2 list-disc pl-5 text-sm">
-            <li>
-              <a className="underline hover:no-underline" href="/chapters/001-prologue">
-                Prologue — On Names, Memory, and Return
-              </a>
-            </li>
-            <li>
-              <a className="underline hover:no-underline" href="/chapters/002-foundations-canaanite-networks">
-                Foundations — Canaanite Urban Networks (-2000 to -1200)
-              </a>
-            </li>
-          </ul>
-        </div>
-      </section>
-
-      <p className="mt-10 text-sm text-gray-600">
-        <a className="underline hover:no-underline" href="/ar">
-          View this site in Arabic →
+      <p className="mt-8 text-sm text-gray-600">
+        <a className="underline hover:no-underline" href={enHref}>
+          ← English
         </a>
       </p>
-
-      <footer className="mt-12 text-xs text-gray-500">Code: MIT · Content: CC BY-SA 4.0</footer>
     </main>
   );
 }

--- a/app/(site)/ar/page.tsx
+++ b/app/(site)/ar/page.tsx
@@ -1,24 +1,49 @@
-import '../../globals.css';
-import type { ReactNode } from 'react';
+// app/(site)/ar/page.tsx
+import dynamic from 'next/dynamic';
+import { loadSearchDocs } from '@/lib/loaders.search';
 
 export const metadata = {
   title: 'فلسطين',
-  description: 'تاريخ عام وفني لفلسطين'
-};
+  description: 'تأريخ رقمي عامّ لفلسطين يمتد عبر ٤٠٠٠ سنة — يركز على الحياة الفلسطينية والمصادر والذاكرة المناهضة للاستعمار.',
+  alternates: { languages: { en: '/' } },
+} as const;
+
+const Search = dynamic(() => import('@/components/Search'), { ssr: false });
 
 export default function Page() {
-  return (
-    <main className="mx-auto max-w-3xl px-4 py-12">
-      <h1 className="text-3xl font-semibold tracking-tight">فلسطين</h1>
-      <p className="mt-2 text-base text-gray-700">
-        هذا هو المسار العربي. سنضيف فصولاً وواجهة بالعربية لاحقًا.
-      </p>
+  const docs = loadSearchDocs();
 
-      <p className="mt-4">
-        <a className="underline hover:no-underline" href="/ar/chapters/001-prologue">
-          ← قراءة المقدّمة
+  return (
+    <main className="mx-auto max-w-3xl px-4 py-12 font-arabic" dir="rtl" lang="ar">
+      <header className="mb-8">
+        <h1 className="text-3xl font-semibold tracking-tight">فلسطين</h1>
+        <p className="mt-2 text-base text-gray-600">
+          تأريخ رقمي عامّ لفلسطين يمتد عبر ٤٠٠٠ سنة — يركز على الحياة الفلسطينية والمصادر والذاكرة المناهضة للاستعمار.
+        </p>
+      </header>
+
+      <div className="mb-6">
+        <Search docs={docs} />
+      </div>
+
+      <section className="space-y-4">
+        <div className="space-x-3" dir="ltr">
+          <a href="/ar/timeline" className="inline-block rounded border px-3 py-2 text-sm hover:bg-gray-50">
+            استكشف الخط الزمني
+          </a>
+          <a href="/ar/maps" className="inline-block rounded border px-3 py-2 text-sm hover:bg-gray-50">
+            عرض الأماكن على الخريطة
+          </a>
+        </div>
+      </section>
+
+      <p className="mt-10 text-sm text-gray-600">
+        <a className="underline hover:no-underline" href="/">
+          عرض هذه الصفحة بالإنجليزية →
         </a>
       </p>
+
+      <footer className="mt-12 text-xs text-gray-500">Code: MIT · Content: CC BY-SA 4.0</footer>
     </main>
   );
 }

--- a/app/(site)/ar/page.tsx
+++ b/app/(site)/ar/page.tsx
@@ -4,14 +4,33 @@ import { loadSearchDocs } from '@/lib/loaders.search';
 
 export const metadata = {
   title: 'فلسطين',
-  description: 'تأريخ رقمي عامّ لفلسطين يمتد عبر ٤٠٠٠ سنة — يركز على الحياة الفلسطينية والمصادر والذاكرة المناهضة للاستعمار.',
+  description:
+    'تأريخ رقمي عامّ لفلسطين يمتد عبر ٤٠٠٠ سنة — يركز على الحياة الفلسطينية والمصادر والذاكرة المناهضة للاستعمار.',
   alternates: { languages: { en: '/' } },
 } as const;
 
 const Search = dynamic(() => import('@/components/Search'), { ssr: false });
 
+type AnyDoc = Record<string, unknown>;
+
+function toView(d: AnyDoc) {
+  const href =
+    (d as any).href ??
+    (d as any).url ??
+    (d as any).path ??
+    ((d as any).slug ? `/chapters/${(d as any).slug}` : '#');
+
+  return {
+    title: String((d as any).title ?? ''),
+    summary: String((d as any).summary ?? ''),
+    tags: Array.isArray((d as any).tags) ? (d as any).tags.map(String) : [],
+    lang: (d as any).lang,
+    href,
+  };
+}
+
 export default function Page() {
-  const docs = loadSearchDocs();
+  const docs = loadSearchDocs().map(toView);
 
   return (
     <main className="mx-auto max-w-3xl px-4 py-12 font-arabic" dir="rtl" lang="ar">
@@ -26,8 +45,8 @@ export default function Page() {
         <Search docs={docs} />
       </div>
 
-      <section className="space-y-4">
-        <div className="space-x-3" dir="ltr">
+      <section className="space-y-4" dir="ltr">
+        <div className="space-x-3">
           <a href="/ar/timeline" className="inline-block rounded border px-3 py-2 text-sm hover:bg-gray-50">
             استكشف الخط الزمني
           </a>

--- a/app/(site)/ar/page.tsx
+++ b/app/(site)/ar/page.tsx
@@ -9,10 +9,10 @@ export const metadata = {
   alternates: { languages: { en: '/' } },
 } as const;
 
+// Client-only Search to avoid SSR/client ordering mismatches
 const Search = dynamic(() => import('@/components/Search'), { ssr: false });
 
 type AnyDoc = Record<string, unknown>;
-
 function toView(d: AnyDoc) {
   const href =
     (d as any).href ??

--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -1,30 +1,19 @@
 // app/(site)/page.tsx
-import { loadSearchDocs, type SearchDoc } from '@/lib/loaders.search';
-import Search from '@/components/Search';
+import dynamic from 'next/dynamic';
+import { loadSearchDocs } from '@/lib/loaders.search';
 
-type SearchDocView = {
-  title: string;
-  summary?: string;
-  tags?: string[];
-  href: string;
-};
+export const metadata = {
+  title: 'Palestine',
+  description:
+    'A public, art-grade digital history spanning 4,000 years — centering Palestinian life, sources, and anti-colonial memory.',
+  alternates: { languages: { ar: '/ar' } },
+} as const;
 
-function toView(d: SearchDoc): SearchDocView {
-  // Map loader docs → Search docs with concrete hrefs
-  if (d.kind === 'chapter' && d.slug) {
-    return { title: d.title, summary: d.summary, tags: d.tags, href: `/chapters/${d.slug}` };
-  }
-  if (d.kind === 'place' && d.slug) {
-    return { title: d.title, summary: d.summary, tags: d.tags, href: `/places/${d.slug}` };
-  }
-  if (d.kind === 'timeline') {
-    return { title: d.title, summary: d.summary, tags: d.tags, href: '/timeline' };
-  }
-  return { title: d.title, summary: d.summary, tags: d.tags, href: '#' };
-}
+// Client-only Search to avoid SSR/client ordering mismatches
+const Search = dynamic(() => import('@/components/Search'), { ssr: false });
 
 export default function Page() {
-  const docs = loadSearchDocs().map(toView);
+  const docs = loadSearchDocs();
 
   return (
     <main className="mx-auto max-w-3xl px-4 py-12">
@@ -36,7 +25,6 @@ export default function Page() {
         </p>
       </header>
 
-      {/* Site search */}
       <div className="mb-6">
         <Search docs={docs} />
       </div>
@@ -68,16 +56,13 @@ export default function Page() {
         </div>
       </section>
 
-      {/* Language toggle */}
       <p className="mt-10 text-sm text-gray-600">
         <a className="underline hover:no-underline" href="/ar">
           View this site in Arabic →
         </a>
       </p>
 
-      <footer className="mt-12 text-xs text-gray-500">
-        Code: MIT · Content: CC BY-SA 4.0
-      </footer>
+      <footer className="mt-12 text-xs text-gray-500">Code: MIT · Content: CC BY-SA 4.0</footer>
     </main>
   );
 }

--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -12,8 +12,28 @@ export const metadata = {
 // Client-only Search to avoid SSR/client ordering mismatches
 const Search = dynamic(() => import('@/components/Search'), { ssr: false });
 
+type AnyDoc = Record<string, unknown>;
+
+function toView(d: AnyDoc) {
+  // Guarantee href for Search’s prop type
+  const href =
+    (d as any).href ??
+    (d as any).url ??
+    (d as any).path ??
+    ((d as any).slug ? `/chapters/${(d as any).slug}` : '#');
+
+  return {
+    // preserve known fields if present
+    title: String((d as any).title ?? ''),
+    summary: String((d as any).summary ?? ''),
+    tags: Array.isArray((d as any).tags) ? (d as any).tags.map(String) : [],
+    lang: (d as any).lang,
+    href,
+  };
+}
+
 export default function Page() {
-  const docs = loadSearchDocs();
+  const docs = loadSearchDocs().map(toView);
 
   return (
     <main className="mx-auto max-w-3xl px-4 py-12">


### PR DESCRIPTION
- **fix(home): make Search a client-only island via dynamic import to prevent hydration mismatches**
- **fix(home): map SearchDoc→Doc by guaranteeing href; keep Search client-only to avoid hydration mismatch**
- **fix(ar/maps): remove stray Search; render MapsPageClientAr with gazetteer + cfg**
- **fix(ar): restore correct Arabic home and maps pages; remove stray Search from /ar/maps**
