### PR TITLE
fix/home ordering

### DIFF
--- a/app/(site)/ar/page.tsx
+++ b/app/(site)/ar/page.tsx
@@ -1,5 +1,5 @@
 // app/(site)/ar/page.tsx
-import dynamic from 'next/dynamic';
+import SearchIsland from '@/components/SearchIsland';
 import { loadSearchDocs } from '@/lib/loaders.search';
 
 export const metadata = {
@@ -8,8 +8,6 @@ export const metadata = {
     'تأريخ رقمي عامّ لفلسطين يمتد عبر ٤٠٠٠ سنة — يركز على الحياة الفلسطينية والمصادر والذاكرة المناهضة للاستعمار.',
   alternates: { languages: { en: '/' } },
 } as const;
-
-const Search = dynamic(() => import('@/components/Search'), { ssr: false, loading: () => null });
 
 type AnyDoc = Record<string, unknown>;
 function toView(d: AnyDoc) {
@@ -23,13 +21,17 @@ function toView(d: AnyDoc) {
     title: String((d as any).title ?? ''),
     summary: String((d as any).summary ?? ''),
     tags: Array.isArray((d as any).tags) ? (d as any).tags.map(String) : [],
-    lang: (d as any).lang,
+    lang: (d as any).lang ?? (d as any).language ?? 'ar',
     href,
   };
 }
 
 export default function Page() {
-  const docs = loadSearchDocs().map(toView);
+  const all = loadSearchDocs().map(toView);
+  const ar = all.filter((d) => d.lang === 'ar');
+  const en = all.filter((d) => d.lang === 'en');
+  const rest = all.filter((d) => d.lang !== 'en' && d.lang !== 'ar');
+  const docs = [...ar, ...rest, ...en]; // AR first on Arabic homepage
 
   return (
     <main className="mx-auto max-w-3xl px-4 py-12 font-arabic" dir="rtl" lang="ar">
@@ -40,8 +42,8 @@ export default function Page() {
         </p>
       </header>
 
-      <div className="mb-6" suppressHydrationWarning>
-        <Search docs={docs} />
+      <div className="mb-6">
+        <SearchIsland docs={docs} />
       </div>
 
       <section className="space-y-4" dir="ltr">

--- a/app/(site)/layout.tsx
+++ b/app/(site)/layout.tsx
@@ -1,26 +1,10 @@
-import '../globals.css';
+// app/(site)/layout.tsx
 import type { ReactNode } from 'react';
-import { Inter } from 'next/font/google';
-import { Noto_Naskh_Arabic } from 'next/font/google';
 
-const inter = Inter({ subsets: ['latin'], variable: '--font-inter' });
-const naskh = Noto_Naskh_Arabic({
-  subsets: ['arabic'],
-  variable: '--font-naskh',
-  weight: ['400', '700']
-});
-
-export const metadata = {
-  title: 'Palestine',
-  description: 'A public, art-grade digital history of Palestine'
-};
-
-export default function RootLayout({ children }: { children: ReactNode }) {
-  return (
-    <html lang="en" dir="ltr">
-      <body className={`${inter.variable} ${naskh.variable} font-sans`}>
-        {children}
-      </body>
-    </html>
-  );
+/**
+ * Segment layout for (site).
+ * NOTE: Do not render <html> or <body> here; the root layout handles that.
+ */
+export default function SiteSegmentLayout({ children }: { children: ReactNode }) {
+  return <>{children}</>;
 }

--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -1,5 +1,5 @@
 // app/(site)/page.tsx
-import dynamic from 'next/dynamic';
+import SearchIsland from '@/components/SearchIsland';
 import { loadSearchDocs } from '@/lib/loaders.search';
 
 export const metadata = {
@@ -8,8 +8,6 @@ export const metadata = {
     'A public, art-grade digital history spanning 4,000 years — centering Palestinian life, sources, and anti-colonial memory.',
   alternates: { languages: { ar: '/ar' } },
 } as const;
-
-const Search = dynamic(() => import('@/components/Search'), { ssr: false, loading: () => null });
 
 type AnyDoc = Record<string, unknown>;
 function toView(d: AnyDoc) {
@@ -23,13 +21,17 @@ function toView(d: AnyDoc) {
     title: String((d as any).title ?? ''),
     summary: String((d as any).summary ?? ''),
     tags: Array.isArray((d as any).tags) ? (d as any).tags.map(String) : [],
-    lang: (d as any).lang,
+    lang: (d as any).lang ?? (d as any).language ?? 'en',
     href,
   };
 }
 
 export default function Page() {
-  const docs = loadSearchDocs().map(toView);
+  const all = loadSearchDocs().map(toView);
+  const en = all.filter((d) => d.lang === 'en');
+  const ar = all.filter((d) => d.lang === 'ar');
+  const rest = all.filter((d) => d.lang !== 'en' && d.lang !== 'ar');
+  const docs = [...en, ...rest, ...ar]; // EN first on English homepage
 
   return (
     <main className="mx-auto max-w-3xl px-4 py-12">
@@ -41,9 +43,8 @@ export default function Page() {
         </p>
       </header>
 
-      {/* Client-only island; avoid hydration claims on this subtree */}
-      <div className="mb-6" suppressHydrationWarning>
-        <Search docs={docs} />
+      <div className="mb-6">
+        <SearchIsland docs={docs} />
       </div>
 
       <section className="space-y-4">

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,60 +1,36 @@
 // app/layout.tsx
 import './globals.css';
-import type { Metadata, Viewport } from 'next';
-import { Inter, Noto_Naskh_Arabic } from 'next/font/google';
-import { Analytics } from '@vercel/analytics/react';
-import { SpeedInsights } from '@vercel/speed-insights/next';
+import type { ReactNode } from 'react';
+import { Inter } from 'next/font/google';
+import { Noto_Naskh_Arabic } from 'next/font/google';
 
 const inter = Inter({ subsets: ['latin'], variable: '--font-inter' });
 const naskh = Noto_Naskh_Arabic({
   subsets: ['arabic'],
-  weight: ['400', '700'],
   variable: '--font-naskh',
+  weight: ['400', '700'],
 });
 
-const site = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://palestine.example';
-const titleDefault = 'Palestine — 4,000 Years of Memory';
-const description =
-  'A bilingual, anti-colonial history of Palestine across 4,000 years — maps, timelines, sources, and chapters.';
-
-export const metadata: Metadata = {
-  metadataBase: new URL(site),
-  title: { default: titleDefault, template: '%s · Palestine' },
-  description,
-  alternates: {
-    canonical: '/',
-    languages: { en: '/', ar: '/ar' },
-  },
+export const metadata = {
+  title: 'Palestine — 4,000 Years of Memory',
+  description:
+    'A bilingual, anti-colonial history of Palestine across 4,000 years — maps, timelines, sources, and chapters.',
   openGraph: {
+    title: 'Palestine — 4,000 Years of Memory',
+    description:
+      'A bilingual, anti-colonial history of Palestine across 4,000 years — maps, timelines, sources, and chapters.',
     type: 'website',
-    url: site,
-    siteName: 'Palestine',
-    title: titleDefault,
-    description,
-    images: [{ url: '/opengraph-image', width: 1200, height: 630 }],
   },
-  twitter: {
-    card: 'summary_large_image',
-    title: titleDefault,
-    description,
-    images: ['/opengraph-image'],
+  alternates: {
+    languages: { ar: '/ar' },
   },
-  icons: { icon: '/favicon.ico' },
 };
 
-export const viewport: Viewport = {
-  themeColor: '#ffffff',
-  colorScheme: 'light',
-};
-
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="en">
-      {/* Arabic pages set dir/lang on their own page components */}
+    <html lang="en" suppressHydrationWarning>
       <body className={`${inter.variable} ${naskh.variable} font-sans`}>
         {children}
-        <Analytics />
-        <SpeedInsights />
       </body>
     </html>
   );

--- a/components/SearchIsland.tsx
+++ b/components/SearchIsland.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Search, { type Doc } from './Search';
+
+type Props = { docs: Doc[] };
+
+/** Client-only mount gate to avoid SSR/CSR mismatch for the Search UI. */
+export default function SearchIsland({ docs }: Props) {
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+  if (!mounted) return null;
+  return <Search docs={docs} />;
+}

--- a/lib/loaders.search.ts
+++ b/lib/loaders.search.ts
@@ -1,7 +1,8 @@
+// lib/loaders.search.ts
 import fs from 'node:fs';
 import path from 'node:path';
 import matter from 'gray-matter';
-import { loadTimeline } from '@/lib/loaders';
+import { loadTimelineEvents } from '@/lib/loaders.timeline';
 
 export type SearchDoc = {
   id: string;
@@ -10,35 +11,65 @@ export type SearchDoc = {
   slug?: string;
   summary?: string;
   tags?: string[];
+  /** language hint for deterministic home ordering */
+  lang?: 'en' | 'ar';
 };
+
+/** Infer language from frontmatter or filename (e.g., 001-prologue.ar.mdx) */
+function inferLang(slug: string, fmLang: unknown): 'en' | 'ar' {
+  if (typeof fmLang === 'string') {
+    const v = fmLang.trim().toLowerCase();
+    if (v === 'ar' || v === 'arabic') return 'ar';
+    if (v === 'en' || v === 'english') return 'en';
+  }
+  return /\.ar$/i.test(slug) ? 'ar' : 'en';
+}
 
 export function loadSearchDocs(): SearchDoc[] {
   const docs: SearchDoc[] = [];
 
-  // Chapters (MDX)
-  const chDir = path.join(process.cwd(), 'content', 'chapters');
-  for (const file of fs.readdirSync(chDir).filter(f => f.endsWith('.mdx'))) {
-    const slug = file.replace(/\.mdx$/, '');
-    const raw = fs.readFileSync(path.join(chDir, file), 'utf8');
-    const { data } = matter(raw);
-    docs.push({
-      id: `chapter:${slug}`,
-      kind: 'chapter',
-      title: String(data.title ?? slug),
-      slug,
-      summary: data.summary ?? '',
-      tags: data.tags ?? []
-    });
+  // -------- Chapters (MDX) --------
+  const chapterDir = path.join(process.cwd(), 'content', 'chapters');
+  if (fs.existsSync(chapterDir)) {
+    const files = fs
+      .readdirSync(chapterDir)
+      .filter((f) => f.toLowerCase().endsWith('.mdx'))
+      .sort(); // keep filesystem order stable
+
+    for (const file of files) {
+      const slug = file.replace(/\.mdx$/i, '');
+      const raw = fs.readFileSync(path.join(chapterDir, file), 'utf8');
+      const { data } = matter(raw);
+
+      const title =
+        (typeof data?.title === 'string' && data.title.trim()) ||
+        slug.replace(/[-_]+/g, ' ');
+      const summary = typeof data?.summary === 'string' ? data.summary : '';
+      const tags = Array.isArray(data?.tags) ? data.tags.map(String) : [];
+      const lang = inferLang(slug, (data as any)?.language);
+
+      docs.push({
+        id: `chapter:${slug}`,
+        kind: 'chapter',
+        title,
+        slug,
+        summary,
+        tags,
+        lang,
+      });
+    }
   }
 
-  // Timeline (YAML)
-  for (const ev of loadTimeline()) {
+  // -------- Timeline (YAML) --------
+  // Treat as neutral, but default to 'en' for EN-home ordering.
+  for (const ev of loadTimelineEvents()) {
     docs.push({
       id: `timeline:${ev.id}`,
       kind: 'timeline',
       title: ev.title,
-      summary: ev.summary,
-      tags: ev.tags
+      summary: ev.summary ?? '',
+      tags: ev.tags ?? [],
+      lang: 'en',
     });
   }
 


### PR DESCRIPTION
- **fix(home): Client-only SearchIsland with explicit props; partition-and-order docs by language (EN on /, AR on /ar)**
- **fix(layouts): move fonts and <html>/<body> to root layout; make (site) layout pass-through to stop hydration mismatch**
- **fix(home): deterministic EN/AR ordering via lang hint; (site) layout pass-through**
