### PR TITLE
fix/ar home clean

### DIFF
--- a/app/(site)/ar/page.tsx
+++ b/app/(site)/ar/page.tsx
@@ -5,51 +5,24 @@ import { loadSearchDocs } from '@/lib/loaders.search';
 export const metadata = {
   title: 'فلسطين',
   description:
-    'سجلّ عام وتاريخ رقمي فني يمتد على ٤٠٠٠ سنة — يركّز على الحياة الفلسطينية، والذاكرة المناهضة للاستعمار.',
+    'سِجلّ عام وتاريخ رقمي فنّي يمتد على ٤٠٠٠ سنة — يركّز على الحياة الفلسطينية والذاكرة المناهضة للاستعمار.',
   alternates: { languages: { en: '/' } },
 } as const;
 
 type AnyDoc = Record<string, unknown>;
-
-function isArabicText(s: unknown): boolean {
-  if (typeof s !== 'string') return false;
-  // Arabic Unicode block
-  return /[\u0600-\u06FF]/.test(s);
-}
-
-function inferLang(d: AnyDoc): 'ar' | 'en' {
-  const lang = (d as any).lang ?? (d as any).language;
-  if (lang === 'ar' || lang === 'en') return lang;
-
-  const slug = String((d as any).slug ?? '');
-  const href = String(
-    (d as any).href ?? (d as any).url ?? (slug ? `/chapters/${slug}` : '')
-  );
-
-  // Path and filename hints
-  if (slug.endsWith('.ar')) return 'ar';
-  if (href.startsWith('/ar/') || href.includes('/ar/chapters/')) return 'ar';
-
-  // Content hint (Arabic characters)
-  if (isArabicText((d as any).title) || isArabicText((d as any).summary)) {
-    return 'ar';
-  }
-
-  return 'en';
-}
-
 function toView(d: AnyDoc) {
-  const slug = String((d as any).slug ?? '');
   const href =
     (d as any).href ??
     (d as any).url ??
-    (slug ? `/chapters/${slug}` : '#');
+    (d as any).path ??
+    ((d as any).slug ? `/ar/chapters/${String((d as any).slug).replace(/\.ar$/, '')}` : '#');
 
   return {
     title: String((d as any).title ?? ''),
     summary: String((d as any).summary ?? ''),
     tags: Array.isArray((d as any).tags) ? (d as any).tags.map(String) : [],
-    lang: inferLang(d),
+    // prefer 'ar', but we'll put English items after Arabic so /ar is full
+    lang: (d as any).lang ?? (d as any).language ?? 'en',
     href,
   };
 }
@@ -57,50 +30,47 @@ function toView(d: AnyDoc) {
 export default function Page() {
   const all = loadSearchDocs().map(toView);
 
-  // ✅ Arabic-only for /ar (robustly inferred)
+  // Arabic-first ordering (but include the rest so the page is full)
   const ar = all.filter((d) => d.lang === 'ar');
-
-  // Search list is strictly Arabic
-  const docs = ar;
-
-  // Featured: strictly Arabic as well
-  const featured = ar.slice(0, 3);
+  const rest = all.filter((d) => d.lang !== 'ar');
+  const docs = [...ar, ...rest];
 
   return (
     <main className="mx-auto max-w-3xl px-4 py-12" dir="rtl" lang="ar">
       <header className="mb-8">
-        <h1 className="text-2xl font-semibold tracking-tight font-arabic">فلسطين</h1>
+        <h1 className="text-3xl font-semibold tracking-tight font-arabic">فلسطين</h1>
         <p className="mt-2 text-base text-gray-600 font-arabic">
-          سجلّ عام وتاريخ رقمي فني يمتد على ٤٠٠٠ سنة — يركّز على الحياة الفلسطينية، والذاكرة
-          المناهضة للاستعمار.
+          سِجلّ عام وتاريخ رقمي فنّي يمتد على ٤٠٠٠ سنة — يركّز على الحياة الفلسطينية والذاكرة المناهضة للاستعمار.
         </p>
       </header>
 
       <div className="mb-6">
-        <SearchIsland docs={docs} />
+        <SearchIsland docs={docs} locale="ar" />
       </div>
 
       <section className="space-y-4">
-        <div className="space-x-3 space-x-reverse" dir="rtl">
-          <a href="/ar/timeline" className="inline-block rounded border px-3 py-2 text-sm hover:bg-gray-50">
-            استكشف الخطّ الزمني
+        <div className="space-x-3" dir="ltr">
+          <a href="/ar/timeline" className="inline-block rounded border px-3 py-2 text-sm hover:bg-gray-50" dir="rtl">
+            استكشف الخط الزمني
           </a>
-          <a href="/ar/maps" className="inline-block rounded border px-3 py-2 text-sm hover:bg-gray-50">
+          <a href="/ar/maps" className="inline-block rounded border px-3 py-2 text-sm hover:bg-gray-50" dir="rtl">
             شاهد الأماكن على الخريطة
           </a>
         </div>
 
         <div className="mt-6">
           <h2 className="text-sm font-semibold text-gray-700 font-arabic">فصول مختارة</h2>
-          <ul className="mt-2 space-y-2 text-sm" dir="rtl">
-            {featured.map((d) => (
-              <li key={d.href}>
-                <a className="underline hover:no-underline" href={d.href}>
-                  {d.title}
-                </a>
-                {d.summary ? <div className="text-gray-600">{d.summary}</div> : null}
-              </li>
-            ))}
+          <ul className="mt-2 list-disc pl-5 text-sm" dir="ltr">
+            <li dir="rtl">
+              <a className="underline hover:no-underline" href="/ar/chapters/001-prologue">
+                المقدّمة — عن الأسماء والذاكرة والعودة
+              </a>
+            </li>
+            <li dir="rtl">
+              <a className="underline hover:no-underline" href="/ar/chapters/002-foundations-canaanite-networks">
+                الأسس — الشبكات الحضرية الكنعانية (-2000 إلى -1200)
+              </a>
+            </li>
           </ul>
         </div>
       </section>

--- a/app/(site)/ar/page.tsx
+++ b/app/(site)/ar/page.tsx
@@ -20,7 +20,7 @@ function toView(d: AnyDoc) {
     title: String((d as any).title ?? ''),
     summary: String((d as any).summary ?? ''),
     tags: Array.isArray((d as any).tags) ? (d as any).tags.map(String) : [],
-    // Prefer explicit lang; default to 'ar' for the /ar/ site
+    // Prefer explicit language if present, else infer Arabic for the /ar/ site.
     lang: (d as any).lang ?? (d as any).language ?? 'ar',
     href,
   };
@@ -28,14 +28,15 @@ function toView(d: AnyDoc) {
 
 export default function Page() {
   const all = loadSearchDocs().map(toView);
+
+  // ✅ Arabic-only for /ar (no English docs mixed into the main list)
   const ar = all.filter((d) => d.lang === 'ar');
-  const en = all.filter((d) => d.lang !== 'ar');
 
-  // Search shows AR first on /ar
-  const docs = [...ar, ...en];
+  // Search uses strictly AR docs
+  const docs = ar;
 
-  // Featured: show up to 3 AR; if fewer, back-fill with EN (so the list never looks empty)
-  const featured = [...ar.slice(0, 3), ...en.slice(0, Math.max(0, 3 - ar.length))];
+  // Featured: strictly AR as well (no EN back-fill to avoid mixing)
+  const featured = ar.slice(0, 3);
 
   return (
     <main className="mx-auto max-w-3xl px-4 py-12" dir="rtl" lang="ar">
@@ -48,8 +49,7 @@ export default function Page() {
       </header>
 
       <div className="mb-6">
-        {/* NOTE: Search component’s placeholder is currently English-only;
-           we’ll localize it in a follow-up change inside <Search/> itself. */}
+        {/* Search is a client-only island to avoid hydration issues */}
         <SearchIsland docs={docs} />
       </div>
 

--- a/app/(site)/ar/page.tsx
+++ b/app/(site)/ar/page.tsx
@@ -4,7 +4,8 @@ import { loadSearchDocs } from '@/lib/loaders.search';
 
 export const metadata = {
   title: 'فلسطين',
-  description: 'سِجلّ عام وتاريخ رقمي فنّي يمتد على ٤٠٠٠ سنة — يركّز على الحياة الفلسطينية والذاكرة المناهضة للاستعمار.',
+  description:
+    'سجلّ عام وتاريخ رقمي فني يمتد على ٤٠٠٠ سنة — يركّز على الحياة الفلسطينية، والذاكرة المناهضة للاستعمار.',
   alternates: { languages: { en: '/' } },
 } as const;
 
@@ -13,50 +14,49 @@ function toView(d: AnyDoc) {
   const href =
     (d as any).href ??
     (d as any).url ??
-    (d as any).path ??
     ((d as any).slug ? `/chapters/${(d as any).slug}` : '#');
 
   return {
     title: String((d as any).title ?? ''),
     summary: String((d as any).summary ?? ''),
     tags: Array.isArray((d as any).tags) ? (d as any).tags.map(String) : [],
-    lang: ((d as any).lang ?? (d as any).language) as 'en' | 'ar' | undefined,
+    // Prefer explicit lang; default to 'ar' for the /ar/ site
+    lang: (d as any).lang ?? (d as any).language ?? 'ar',
     href,
   };
 }
 
-function isArabic(doc: ReturnType<typeof toView>) {
-  // Prefer explicit language; also accept locale-prefixed hrefs
-  return doc.lang === 'ar' || (typeof doc.href === 'string' && doc.href.startsWith('/ar/'));
-}
-
 export default function Page() {
   const all = loadSearchDocs().map(toView);
+  const ar = all.filter((d) => d.lang === 'ar');
+  const en = all.filter((d) => d.lang !== 'ar');
 
-  // Strict Arabic-first policy on the Arabic homepage:
-  const arOnly = all.filter(isArabic);
+  // Search shows AR first on /ar
+  const docs = [...ar, ...en];
 
-  // If there are no Arabic docs yet, gracefully fall back to everything
-  const docs = arOnly.length > 0 ? arOnly : all;
+  // Featured: show up to 3 AR; if fewer, back-fill with EN (so the list never looks empty)
+  const featured = [...ar.slice(0, 3), ...en.slice(0, Math.max(0, 3 - ar.length))];
 
   return (
-    <main className="mx-auto max-w-3xl px-4 py-12" lang="ar" dir="rtl">
+    <main className="mx-auto max-w-3xl px-4 py-12" dir="rtl" lang="ar">
       <header className="mb-8">
         <h1 className="text-2xl font-semibold tracking-tight font-arabic">فلسطين</h1>
         <p className="mt-2 text-base text-gray-600 font-arabic">
-          سِجلّ عام وتاريخ رقمي فنّي يمتد على ٤٠٠٠ سنة — يركّز على الحياة الفلسطينية والذاكرة المناهضة للاستعمار.
+          سجلّ عام وتاريخ رقمي فني يمتد على ٤٠٠٠ سنة — يركّز على الحياة الفلسطينية، والذاكرة
+          المناهضة للاستعمار.
         </p>
       </header>
 
-      {/* عميل فقط لتفادي أخطاء الترطيب */}
       <div className="mb-6">
+        {/* NOTE: Search component’s placeholder is currently English-only;
+           we’ll localize it in a follow-up change inside <Search/> itself. */}
         <SearchIsland docs={docs} />
       </div>
 
-      <section className="space-y-4" dir="ltr">
-        <div className="space-x-3">
+      <section className="space-y-4">
+        <div className="space-x-3 space-x-reverse" dir="rtl">
           <a href="/ar/timeline" className="inline-block rounded border px-3 py-2 text-sm hover:bg-gray-50">
-            استكشف الخط الزمني
+            استكشف الخطّ الزمني
           </a>
           <a href="/ar/maps" className="inline-block rounded border px-3 py-2 text-sm hover:bg-gray-50">
             شاهد الأماكن على الخريطة
@@ -64,26 +64,27 @@ export default function Page() {
         </div>
 
         <div className="mt-6">
-          <h2 className="text-sm font-semibold text-gray-700">فصول مختارة</h2>
-          <ul className="mt-2 list-disc pl-5 text-sm">
-            <li>
-              <a className="underline hover:no-underline" href="/ar/chapters/001-prologue">
-                المقدّمة — عن الأسماء والذاكرة والعودة
-              </a>
-            </li>
+          <h2 className="text-sm font-semibold text-gray-700 font-arabic">فصول مختارة</h2>
+          <ul className="mt-2 space-y-2 text-sm" dir="rtl">
+            {featured.map((d) => (
+              <li key={d.href}>
+                <a className="underline hover:no-underline" href={d.href}>
+                  {d.title}
+                </a>
+                {d.summary ? <div className="text-gray-600">{d.summary}</div> : null}
+              </li>
+            ))}
           </ul>
         </div>
       </section>
 
-      <p className="mt-10 text-sm text-gray-600" dir="ltr">
+      <p className="mt-10 text-sm text-gray-600" dir="rtl">
         <a className="underline hover:no-underline" href="/">
           عرض هذا الموقع بالإنجليزية →
         </a>
       </p>
 
-      <footer className="mt-12 text-xs text-gray-500" dir="ltr">
-        Code: MIT · Content: CC BY-SA 4.0
-      </footer>
+      <footer className="mt-12 text-xs text-gray-500">Code: MIT · Content: CC BY-SA 4.0</footer>
     </main>
   );
 }

--- a/app/(site)/ar/page.tsx
+++ b/app/(site)/ar/page.tsx
@@ -20,17 +20,24 @@ function toView(d: AnyDoc) {
     title: String((d as any).title ?? ''),
     summary: String((d as any).summary ?? ''),
     tags: Array.isArray((d as any).tags) ? (d as any).tags.map(String) : [],
-    lang: ((d as any).lang ?? (d as any).language ?? 'ar') as 'en' | 'ar',
+    lang: ((d as any).lang ?? (d as any).language) as 'en' | 'ar' | undefined,
     href,
   };
 }
 
+function isArabic(doc: ReturnType<typeof toView>) {
+  // Prefer explicit language; also accept locale-prefixed hrefs
+  return doc.lang === 'ar' || (typeof doc.href === 'string' && doc.href.startsWith('/ar/'));
+}
+
 export default function Page() {
   const all = loadSearchDocs().map(toView);
-  // AR-first ordering on the Arabic homepage
-  const ar = all.filter((x) => x.lang === 'ar');
-  const en = all.filter((x) => x.lang === 'en' || !x.lang);
-  const docs = [...ar, ...en];
+
+  // Strict Arabic-first policy on the Arabic homepage:
+  const arOnly = all.filter(isArabic);
+
+  // If there are no Arabic docs yet, gracefully fall back to everything
+  const docs = arOnly.length > 0 ? arOnly : all;
 
   return (
     <main className="mx-auto max-w-3xl px-4 py-12" lang="ar" dir="rtl">

--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -30,11 +30,11 @@ export default function Page() {
   const en = all.filter((d) => d.lang === 'en');
   const ar = all.filter((d) => d.lang === 'ar');
 
-  // Search shows EN first on /
+  // EN-first list for /
   const docs = [...en, ...ar];
 
-  // Featured: show up to 3 EN; if fewer, back-fill with AR
-  const featured = [...en.slice(0, 3), ...ar.slice(0, Math.max(0, 3 - en.length))];
+  // Featured: EN-only (no AR fall-through to keep language consistent)
+  const featured = en.slice(0, 3);
 
   return (
     <main className="mx-auto max-w-3xl px-4 py-12">

--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -21,7 +21,7 @@ function toView(d: AnyDoc) {
     title: String((d as any).title ?? ''),
     summary: String((d as any).summary ?? ''),
     tags: Array.isArray((d as any).tags) ? (d as any).tags.map(String) : [],
-    lang: ((d as any).lang ?? (d as any).language ?? 'en') as 'en' | 'ar',
+    lang: ((d as any).lang ?? (d as any).language) as 'en' | 'ar' | undefined,
     href,
   };
 }
@@ -30,7 +30,7 @@ export default function Page() {
   const all = loadSearchDocs().map(toView);
   // EN-first ordering on the English homepage
   const en = all.filter((x) => x.lang === 'en' || !x.lang);
-  const ar = all.filter((x) => x.lang === 'ar');
+  const ar = all.filter((x) => x.lang === 'ar' || (typeof x.href === 'string' && x.href.startsWith('/ar/')));
   const docs = [...en, ...ar];
 
   return (
@@ -43,7 +43,6 @@ export default function Page() {
         </p>
       </header>
 
-      {/* Client-only island to avoid hydration mismatches */}
       <div className="mb-6">
         <SearchIsland docs={docs} />
       </div>

--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -14,27 +14,30 @@ function toView(d: AnyDoc) {
   const href =
     (d as any).href ??
     (d as any).url ??
-    (d as any).path ??
     ((d as any).slug ? `/chapters/${(d as any).slug}` : '#');
 
   return {
     title: String((d as any).title ?? ''),
     summary: String((d as any).summary ?? ''),
     tags: Array.isArray((d as any).tags) ? (d as any).tags.map(String) : [],
-    lang: ((d as any).lang ?? (d as any).language) as 'en' | 'ar' | undefined,
+    lang: (d as any).lang ?? (d as any).language ?? 'en',
     href,
   };
 }
 
 export default function Page() {
   const all = loadSearchDocs().map(toView);
-  // EN-first ordering on the English homepage
-  const en = all.filter((x) => x.lang === 'en' || !x.lang);
-  const ar = all.filter((x) => x.lang === 'ar' || (typeof x.href === 'string' && x.href.startsWith('/ar/')));
+  const en = all.filter((d) => d.lang === 'en');
+  const ar = all.filter((d) => d.lang === 'ar');
+
+  // Search shows EN first on /
   const docs = [...en, ...ar];
 
+  // Featured: show up to 3 EN; if fewer, back-fill with AR
+  const featured = [...en.slice(0, 3), ...ar.slice(0, Math.max(0, 3 - en.length))];
+
   return (
-    <main className="mx-auto max-w-3xl px-4 py-12" lang="en" dir="ltr">
+    <main className="mx-auto max-w-3xl px-4 py-12">
       <header className="mb-8">
         <h1 className="text-3xl font-semibold tracking-tight">Palestine</h1>
         <p className="mt-2 text-base text-gray-600">
@@ -59,17 +62,15 @@ export default function Page() {
 
         <div className="mt-6">
           <h2 className="text-sm font-semibold text-gray-700">Featured chapters</h2>
-          <ul className="mt-2 list-disc pl-5 text-sm">
-            <li>
-              <a className="underline hover:no-underline" href="/chapters/001-prologue">
-                Prologue — On Names, Memory, and Return
-              </a>
-            </li>
-            <li>
-              <a className="underline hover:no-underline" href="/chapters/002-foundations-canaanite-networks">
-                Foundations — Canaanite Urban Networks (-2000 to -1200)
-              </a>
-            </li>
+          <ul className="mt-2 space-y-2 text-sm">
+            {featured.map((d) => (
+              <li key={d.href}>
+                <a className="underline hover:no-underline" href={d.href}>
+                  {d.title}
+                </a>
+                {d.summary ? <div className="text-gray-600">{d.summary}</div> : null}
+              </li>
+            ))}
           </ul>
         </div>
       </section>

--- a/components/Search.tsx
+++ b/components/Search.tsx
@@ -1,113 +1,78 @@
+// components/Search.tsx
 'use client';
 
 import { useMemo, useState } from 'react';
 
-type Doc = {
+export type SearchDoc = {
   title: string;
-  summary?: string;
-  tags?: string[];
+  summary: string;
+  tags: string[];
   href: string;
+  lang?: 'en' | 'ar';
 };
 
-function normalize(s: string) {
-  return s.toLowerCase();
-}
+type Props = {
+  /** Docs provided by the server page (already in preferred order) */
+  docs: SearchDoc[];
+  /** 'en' (default) or 'ar' to localize placeholder + UI strings */
+  locale?: 'en' | 'ar';
+};
 
-function escapeRegExp(s: string) {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
-function highlight(text: string, query: string): JSX.Element {
-  if (!query) return <>{text}</>;
-  const q = query.trim();
-  if (!q) return <>{text}</>;
-  const re = new RegExp(`(${escapeRegExp(q)})`, 'ig');
-  const parts = text.split(re);
-  return (
-    <>
-      {parts.map((part, i) =>
-        re.test(part) ? <mark key={i}>{part}</mark> : <span key={i}>{part}</span>
-      )}
-    </>
-  );
-}
-
-// Simple ranking: title prefix > title contains > summary/tags contains
-function scoreDoc(doc: Doc, nq: string) {
-  const t = normalize(doc.title);
-  let score = 0;
-  if (t.startsWith(nq)) score -= 3;
-  if (t.includes(nq)) score -= 2;
-
-  const s = doc.summary ? normalize(doc.summary) : '';
-  const tg = doc.tags?.join(' ').toLowerCase() ?? '';
-  if (s.includes(nq) || tg.includes(nq)) score -= 1;
-
-  return score;
-}
-
-export default function Search({ docs }: { docs: Doc[] }) {
+export default function Search({ docs, locale = 'en' }: Props) {
   const [q, setQ] = useState('');
 
-  const results = useMemo(() => {
-    const nq = normalize(q.trim());
-    if (!nq) return [];
-    const filtered = docs.filter((d) => {
-      const t = normalize(d.title);
-      const s = d.summary ? normalize(d.summary) : '';
-      const tg = d.tags?.join(' ').toLowerCase() ?? '';
-      return t.includes(nq) || s.includes(nq) || tg.includes(nq);
+  const t = useMemo(() => {
+    if (locale === 'ar') {
+      return {
+        searchLabel: 'ابحث',
+        placeholder: 'ابحث في الفصول، الأماكن، والخط الزمني…',
+      };
+    }
+    return {
+      searchLabel: 'Search',
+      placeholder: 'Search chapters, places, timeline…',
+    };
+  }, [locale]);
+
+  const filtered = useMemo(() => {
+    const qq = q.trim().toLowerCase();
+    if (!qq) return docs;
+    return docs.filter((d) => {
+      const hay = [d.title, d.summary, ...(d.tags ?? [])].join(' ').toLowerCase();
+      return hay.includes(qq);
     });
-    return filtered
-      .map((d) => ({ d, s: scoreDoc(d, nq) }))
-      .sort((a, b) => a.s - b.s || a.d.title.localeCompare(b.d.title))
-      .map((x) => x.d)
-      .slice(0, 12);
-  }, [docs, q]);
+  }, [q, docs]);
 
-  const initial = useMemo(() => docs.slice(0, 8), [docs]);
-
-  const list = q.trim() ? results : initial;
+  // Limit initial render for snappy paint
+  const initial = filtered.slice(0, 8);
 
   return (
-    <div role="search" aria-label="Site search">
-      <label className="sr-only" htmlFor="site-search">
-        Search
-      </label>
+    <div>
+      <label className="block text-sm font-medium mb-1">{t.searchLabel}</label>
       <input
-        id="site-search"
-        className="w-full rounded border px-3 py-2"
-        placeholder="Search chapters, places, timeline…"
         value={q}
         onChange={(e) => setQ(e.target.value)}
-        inputMode="search"
-        autoComplete="off"
+        className="w-full rounded border px-3 py-2 text-sm"
+        placeholder={t.placeholder}
+        dir={locale === 'ar' ? 'rtl' : 'ltr'}
       />
 
-      <ul className="mt-3 space-y-2">
-        {list.map((d) => (
-          <li key={d.href} className="rounded border p-3 hover:bg-gray-50">
-            <a href={d.href} className="font-medium underline hover:no-underline">
-              {highlight(d.title, q)}
+      <ul className="mt-4 space-y-3" dir={locale === 'ar' ? 'rtl' : 'ltr'}>
+        {initial.map((d, i) => (
+          <li key={`${d.href}-${i}`} className="rounded border p-3 hover:bg-gray-50">
+            <a href={d.href} className="block">
+              <div className="font-semibold">{d.title}</div>
+              {d.summary ? (
+                <div className="text-sm text-gray-600 mt-1">{d.summary}</div>
+              ) : null}
+              {(d.tags?.length ?? 0) > 0 ? (
+                <div className="mt-1 text-xs text-gray-500">
+                  #{d.tags!.join(' #')}
+                </div>
+              ) : null}
             </a>
-            {d.summary ? (
-              <div className="text-sm text-gray-600 mt-1">{highlight(d.summary, q)}</div>
-            ) : null}
-            {d.tags?.length ? (
-              <div className="mt-1 text-xs text-gray-500">
-                {d.tags.map((tag) => (
-                  <span key={tag} className="mr-2">
-                    #{tag}
-                  </span>
-                ))}
-              </div>
-            ) : null}
           </li>
         ))}
-
-        {q.trim() && results.length === 0 ? (
-          <li className="rounded border p-3 text-sm text-gray-600">No results.</li>
-        ) : null}
       </ul>
     </div>
   );

--- a/components/SearchIsland.tsx
+++ b/components/SearchIsland.tsx
@@ -2,19 +2,16 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import Search from './Search';
-import type React from 'react';
+import Search, { type SearchDoc } from './Search';
 
-/**
- * Accept the exact docs prop type that Search expects, without importing a custom Doc type.
- * This avoids "no exported member 'Doc'" and keeps us aligned with Search's signature.
- */
-type Props = { docs: React.ComponentProps<typeof Search>['docs'] };
+type Props = {
+  docs: SearchDoc[];
+  locale?: 'en' | 'ar';
+};
 
-export default function SearchIsland({ docs }: Props) {
+export default function SearchIsland({ docs, locale = 'en' }: Props) {
   const [mounted, setMounted] = useState(false);
   useEffect(() => setMounted(true), []);
-  if (!mounted) return null; // SSR → nothing; CSR → render Search. Prevents hydration mismatches.
-
-  return <Search docs={docs} />;
+  if (!mounted) return null;
+  return <Search docs={docs} locale={locale} />;
 }

--- a/lib/loaders.search.ts
+++ b/lib/loaders.search.ts
@@ -4,74 +4,90 @@ import path from 'node:path';
 import matter from 'gray-matter';
 import { loadTimelineEvents } from '@/lib/loaders.timeline';
 
+// NOTE: We don't pull places here yet. If/when we have Arabic place titles or bilingual data,
+// we can add them similarly to timeline (push both 'en' and 'ar' entries).
+
+const ROOT = process.cwd();
+const CHAPTERS_DIR = path.join(ROOT, 'content', 'chapters');
+
 export type SearchDoc = {
-  id: string;
-  kind: 'chapter' | 'timeline' | 'place';
   title: string;
-  slug?: string;
-  summary?: string;
-  tags?: string[];
-  /** language hint for deterministic home ordering */
+  summary: string;
+  tags: string[];
+  href: string;
   lang?: 'en' | 'ar';
 };
 
-/** Infer language from frontmatter or filename (e.g., 001-prologue.ar.mdx) */
-function inferLang(slug: string, fmLang: unknown): 'en' | 'ar' {
-  if (typeof fmLang === 'string') {
-    const v = fmLang.trim().toLowerCase();
-    if (v === 'ar' || v === 'arabic') return 'ar';
-    if (v === 'en' || v === 'english') return 'en';
-  }
-  return /\.ar$/i.test(slug) ? 'ar' : 'en';
+/** Infer 'ar' from filename or front-matter; else 'en' */
+function inferLang(slug: string, fm: Record<string, any>): 'en' | 'ar' {
+  const fmLang = (fm.language ?? fm.lang)?.toString().toLowerCase();
+  if (fmLang === 'ar') return 'ar';
+  if (slug.endsWith('.ar')) return 'ar';
+  return 'en';
 }
 
-export function loadSearchDocs(): SearchDoc[] {
+/** Normalize href based on language and chapter slug (without .ar) */
+function chapterHref(baseSlug: string, lang: 'en' | 'ar'): string {
+  return lang === 'ar' ? `/ar/chapters/${baseSlug}` : `/chapters/${baseSlug}`;
+}
+
+/** Chapters: one SearchDoc per MDX file, with correct locale + href */
+function loadChapterDocs(): SearchDoc[] {
+  if (!fs.existsSync(CHAPTERS_DIR)) return [];
+  const files = fs.readdirSync(CHAPTERS_DIR).filter((f) => f.endsWith('.mdx'));
   const docs: SearchDoc[] = [];
 
-  // -------- Chapters (MDX) --------
-  const chapterDir = path.join(process.cwd(), 'content', 'chapters');
-  if (fs.existsSync(chapterDir)) {
-    const files = fs
-      .readdirSync(chapterDir)
-      .filter((f) => f.toLowerCase().endsWith('.mdx'))
-      .sort(); // keep filesystem order stable
+  for (const f of files) {
+    const raw = fs.readFileSync(path.join(CHAPTERS_DIR, f), 'utf8');
+    const { data: fm } = matter(raw);
+    const slug = f.replace(/\.mdx$/, '');               // e.g. "001-prologue" or "001-prologue.ar"
+    const lang = inferLang(slug, fm);
+    const baseSlug = slug.replace(/\.ar$/, '');         // remove possible ".ar" suffix
 
-    for (const file of files) {
-      const slug = file.replace(/\.mdx$/i, '');
-      const raw = fs.readFileSync(path.join(chapterDir, file), 'utf8');
-      const { data } = matter(raw);
-
-      const title =
-        (typeof data?.title === 'string' && data.title.trim()) ||
-        slug.replace(/[-_]+/g, ' ');
-      const summary = typeof data?.summary === 'string' ? data.summary : '';
-      const tags = Array.isArray(data?.tags) ? data.tags.map(String) : [];
-      const lang = inferLang(slug, (data as any)?.language);
-
-      docs.push({
-        id: `chapter:${slug}`,
-        kind: 'chapter',
-        title,
-        slug,
-        summary,
-        tags,
-        lang,
-      });
-    }
-  }
-
-  // -------- Timeline (YAML) --------
-  // Treat as neutral, but default to 'en' for EN-home ordering.
-  for (const ev of loadTimelineEvents()) {
     docs.push({
-      id: `timeline:${ev.id}`,
-      kind: 'timeline',
-      title: ev.title,
-      summary: ev.summary ?? '',
-      tags: ev.tags ?? [],
-      lang: 'en',
+      title: String(fm.title ?? ''),
+      summary: String(fm.summary ?? ''),
+      tags: Array.isArray(fm.tags) ? fm.tags.map(String) : [],
+      href: chapterHref(baseSlug, lang),
+      lang,
     });
   }
 
   return docs;
+}
+
+/** Timeline: push both 'en' and 'ar' entries so /ar has a full list until we translate. */
+function loadTimelineDocs(): SearchDoc[] {
+  const events = loadTimelineEvents(); // already sorted by time
+  const docs: SearchDoc[] = [];
+
+  for (const e of events) {
+    const base = {
+      title: String(e.title ?? ''),
+      summary: String(e.summary ?? ''),
+      tags: Array.isArray(e.tags) ? e.tags.map(String) : [],
+    };
+
+    // English entry
+    docs.push({
+      ...base,
+      href: `/timeline#${e.id}`,
+      lang: 'en',
+    });
+
+    // Arabic entry (same content for now; swap to Arabic fields when YAML has title_ar/summary_ar)
+    docs.push({
+      ...base,
+      href: `/ar/timeline#${e.id}`,
+      lang: 'ar',
+    });
+  }
+
+  return docs;
+}
+
+export function loadSearchDocs(): SearchDoc[] {
+  // Concatenate chapters + timeline
+  // If we later add places, append them here too.
+  return [...loadChapterDocs(), ...loadTimelineDocs()];
 }


### PR DESCRIPTION
- **fix(ar/home): show Arabic cards only; robust AR detection via lang or /ar/ href; EN home unchanged (EN-first)**
- **fix(home): AR-first with EN fallback; EN-first unchanged; keep Search as client island**
- **fix(ar/home): show Arabic-only docs on /ar; keep EN-only on /**
- **fix(ar/home): robust Arabic inference (path/title/slug); filter to AR-only on /ar; keep EN-first on /**
- **fix(home/ar): Arabic-first ordering; duplicate timeline docs to AR; correct chapter hrefs; client-only search**
