### PR TITLE
fix: normalize MiniSearch documents

### DIFF
--- a/lib/loaders.search.ts
+++ b/lib/loaders.search.ts
@@ -3,17 +3,10 @@ import path from 'node:path';
 import matter from 'gray-matter';
 import { loadTimelineEvents } from '@/lib/loaders.timeline';
 import { translateText } from '@/lib/translate';
+import type { SearchDoc } from '@/lib/search.types';
 
 const ROOT = process.cwd();
 const CHAPTERS_DIR = path.join(ROOT, 'content', 'chapters');
-
-export type SearchDoc = {
-  title: string;
-  summary: string;
-  tags: string[];
-  href: string;
-  lang: 'en' | 'ar';
-};
 
 type ChapterFrontmatter = {
   title?: string;
@@ -47,12 +40,15 @@ async function loadChapterDocs(): Promise<SearchDoc[]> {
     const fm = data as ChapterFrontmatter;
     const baseSlug = file.replace(/\.mdx$/, '');
 
+    const hrefEn = `/chapters/${baseSlug}`;
     const englishDoc: SearchDoc = {
+      id: hrefEn,
       title: String(fm.title ?? ''),
       summary: String(fm.summary ?? ''),
       tags: normaliseTags(fm.tags),
-      href: `/chapters/${baseSlug}`,
+      href: hrefEn,
       lang: 'en',
+      type: 'chapter',
     };
     docs.push(englishDoc);
 
@@ -94,12 +90,15 @@ async function loadChapterDocs(): Promise<SearchDoc[]> {
       tags = translated.filter((t) => t && typeof t === 'string');
     }
 
+    const hrefAr = `/ar/chapters/${baseSlug}`;
     docs.push({
+      id: hrefAr,
       title: titleAr,
       summary: summaryAr,
       tags,
-      href: `/ar/chapters/${baseSlug}`,
+      href: hrefAr,
       lang: 'ar',
+      type: 'chapter',
     });
   }
 
@@ -117,10 +116,13 @@ async function loadTimelineDocs(): Promise<SearchDoc[]> {
       tags: Array.isArray(event.tags) ? event.tags.map(String) : [],
     };
 
+    const hrefEn = `/timeline#${event.id}`;
     docs.push({
+      id: hrefEn,
       ...english,
-      href: `/timeline#${event.id}`,
+      href: hrefEn,
       lang: 'en',
+      type: 'event',
     });
 
     const arTitleNative = event.title_ar ? String(event.title_ar) : '';
@@ -156,12 +158,15 @@ async function loadTimelineDocs(): Promise<SearchDoc[]> {
       continue;
     }
 
+    const hrefAr = `/ar/timeline#${event.id}`;
     docs.push({
+      id: hrefAr,
       title: arTitle || english.title,
       summary: arSummary,
       tags: arTags,
-      href: `/ar/timeline#${event.id}`,
+      href: hrefAr,
       lang: 'ar',
+      type: 'event',
     });
   }
 

--- a/lib/search-normalize.ts
+++ b/lib/search-normalize.ts
@@ -1,0 +1,90 @@
+import type { SearchDoc } from '@/lib/search.types';
+
+type RawDoc = Record<string, unknown>;
+
+type Locale = 'en' | 'ar' | undefined;
+
+function normaliseTags(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.map((tag) => String(tag));
+}
+
+function pickType(value: unknown): SearchDoc['type'] | undefined {
+  if (value === 'chapter' || value === 'event' || value === 'place') {
+    return value;
+  }
+  return undefined;
+}
+
+function pickLang(value: unknown, fallback: Locale): SearchDoc['lang'] | undefined {
+  if (value === 'en' || value === 'ar') {
+    return value;
+  }
+  if (fallback === 'en' || fallback === 'ar') {
+    return fallback;
+  }
+  return undefined;
+}
+
+function coerceSummary(value: unknown): string | undefined {
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (value == null) return undefined;
+  try {
+    return String(value);
+  } catch (err) {
+    console.warn('[search] unable to coerce summary field', err);
+    return undefined;
+  }
+}
+
+export function normalizeSearchDocs(raw: unknown, locale?: 'en' | 'ar'): SearchDoc[] {
+  if (!Array.isArray(raw)) {
+    console.warn('[search] expected an array of documents, received', raw);
+    return [];
+  }
+
+  const seen = new Set<string>();
+  const docs: SearchDoc[] = [];
+
+  raw.forEach((value, index) => {
+    if (!value || typeof value !== 'object') {
+      console.warn('[search] skipping malformed document at index', index, value);
+      return;
+    }
+
+    const entry = value as RawDoc;
+    const idCandidate = entry.id ?? entry.slug ?? entry.href ?? entry.url;
+    const id = idCandidate != null && idCandidate !== '' ? String(idCandidate) : `anon-${index}`;
+
+    if (seen.has(id)) {
+      console.warn('[search] duplicate id, skipping', id, entry);
+      return;
+    }
+
+    const hrefCandidate = entry.href ?? entry.url ?? entry.path;
+    const href = hrefCandidate != null && hrefCandidate !== '' ? String(hrefCandidate) : '/';
+
+    const titleCandidate = entry.title ?? entry.name ?? entry.slug ?? id;
+    const title = titleCandidate != null && titleCandidate !== '' ? String(titleCandidate) : 'Untitled';
+
+    const summary = coerceSummary(entry.summary ?? entry.excerpt ?? entry.description ?? '');
+    const tags = normaliseTags(entry.tags ?? entry.keywords);
+    const lang = pickLang(entry.lang, locale);
+    const type = pickType(entry.type ?? entry.kind);
+
+    seen.add(id);
+    docs.push({
+      id,
+      title,
+      href,
+      summary,
+      tags,
+      lang,
+      type,
+    });
+  });
+
+  return docs;
+}

--- a/lib/search-normalize.ts
+++ b/lib/search-normalize.ts
@@ -69,7 +69,7 @@ export function normalizeSearchDocs(raw: unknown, locale?: 'en' | 'ar'): SearchD
     const titleCandidate = entry.title ?? entry.name ?? entry.slug ?? id;
     const title = titleCandidate != null && titleCandidate !== '' ? String(titleCandidate) : 'Untitled';
 
-    const summary = coerceSummary(entry.summary ?? entry.excerpt ?? entry.description ?? '');
+    const summary = coerceSummary(entry.summary ?? entry.excerpt ?? entry.description);
     const tags = normaliseTags(entry.tags ?? entry.keywords);
     const lang = pickLang(entry.lang, locale);
     const type = pickType(entry.type ?? entry.kind);

--- a/lib/search.ts
+++ b/lib/search.ts
@@ -1,13 +1,8 @@
 // Minimal search types + placeholder functions (we'll wire Lunr/MiniSearch later)
 
-export type SearchDoc = {
-  id: string;
-  kind: 'chapter' | 'timeline' | 'place';
-  title: string;
-  slug?: string;         // for chapters
-  summary?: string;
-  tags?: string[];
-};
+import type { SearchDoc } from '@/lib/search.types';
+
+export type { SearchDoc };
 
 export type SearchResult = {
   doc: SearchDoc;

--- a/lib/search.types.ts
+++ b/lib/search.types.ts
@@ -1,0 +1,9 @@
+export type SearchDoc = {
+  id: string;
+  title: string;
+  href: string;
+  summary?: string;
+  tags?: string[];
+  lang?: 'en' | 'ar';
+  type?: 'chapter' | 'event' | 'place';
+};

--- a/public/search.ar.json
+++ b/public/search.ar.json
@@ -1,5 +1,6 @@
 [
   {
+    "id": "/ar/chapters/001-prologue",
     "title": "المقدّمة — عن الأسماء والذاكرة والعودة",
     "summary": "نطاق المشروع ومنهجيته ومصادره وسياسة كتابة تاريخ فلسطين عبر ٤٠٠٠ سنة.",
     "tags": [
@@ -7,9 +8,12 @@
       "ذاكرة",
       "مصادر"
     ],
-    "href": "/ar/chapters/001-prologue"
+    "href": "/ar/chapters/001-prologue",
+    "lang": "ar",
+    "type": "chapter"
   },
   {
+    "id": "/ar/chapters/002-foundations-canaanite-networks",
     "title": "الأسس — الشبكات الحضرية الكنعانية (-2000 إلى -1200)",
     "summary": "الدويلات المدينية الكنعانية، مسالك التجارة، والثقافة المادية في فلسطين بوصفها أرضية للاستمرار والانقطاع لاحقًا.",
     "tags": [
@@ -18,18 +22,24 @@
       "تجارة",
       "ثقافة-مادية"
     ],
-    "href": "/ar/chapters/002-foundations-canaanite-networks"
+    "href": "/ar/chapters/002-foundations-canaanite-networks",
+    "lang": "ar",
+    "type": "chapter"
   },
   {
+    "id": "/ar/timeline#canaanite-networks",
     "title": "ازدهار الشبكات الحضرية الكنعانية",
     "summary": "يعزّز التبادل الحضري عبر بلاد الشام المدن-الدول والتجارة البحرية.",
     "tags": [
       "الاقتصاد",
       "التمدّن"
     ],
-    "href": "/ar/timeline#canaanite-networks"
+    "href": "/ar/timeline#canaanite-networks",
+    "lang": "ar",
+    "type": "event"
   },
   {
+    "id": "/ar/timeline#balfour-declaration",
     "title": "إعلان بلفور يعلن دعم بريطانيا لوطن لليهود",
     "summary": "يُعلن وزير الخارجية آرثر بلفور دعم بريطانيا لإنشاء \"وطن قومي للشعب اليهودي\" في فلسطين، ما يرسّخ السيطرة الاستعمارية.",
     "tags": [
@@ -37,9 +47,12 @@
       "الاستعمار",
       "الدبلوماسية"
     ],
-    "href": "/ar/timeline#balfour-declaration"
+    "href": "/ar/timeline#balfour-declaration",
+    "lang": "ar",
+    "type": "event"
   },
   {
+    "id": "/ar/timeline#nakba-1948",
     "title": "النكبة — تهجير جماعي وتدمير",
     "summary": "تهجير أكثر من 700 ألف فلسطيني وتدمير أو إفراغ أكثر من 400 قرية.",
     "tags": [
@@ -47,9 +60,12 @@
       "العنف",
       "الحرب"
     ],
-    "href": "/ar/timeline#nakba-1948"
+    "href": "/ar/timeline#nakba-1948",
+    "lang": "ar",
+    "type": "event"
   },
   {
+    "id": "/ar/timeline#arab-revolt-1936-39",
     "title": "ثورة 1936–1939 العربية",
     "summary": "انتفاضة فلسطينية متواصلة ضد الحكم الاستعماري البريطاني والاستيطان الصهيوني، قمعتها بريطانيا بقمع واسع.",
     "tags": [
@@ -57,9 +73,12 @@
       "الانتداب-البريطاني",
       "الاستعمار"
     ],
-    "href": "/ar/timeline#arab-revolt-1936-39"
+    "href": "/ar/timeline#arab-revolt-1936-39",
+    "lang": "ar",
+    "type": "event"
   },
   {
+    "id": "/ar/timeline#deir-yassin-1948",
     "title": "مجزرة دير ياسين",
     "summary": "قتلت قوات الإرجون والليحي عشرات القرويين الفلسطينيين، مما سرّع موجات الهروب والطرد خلال النكبة.",
     "tags": [
@@ -67,9 +86,12 @@
       "النكبة",
       "الحرب"
     ],
-    "href": "/ar/timeline#deir-yassin-1948"
+    "href": "/ar/timeline#deir-yassin-1948",
+    "lang": "ar",
+    "type": "event"
   },
   {
+    "id": "/ar/timeline#lydda-ramle-expulsions-1948",
     "title": "تهجير اللد والرملة",
     "summary": "أوامر عسكرية بطرد جماعي؛ أُجبر عشرات الآلاف على الرحيل في ذروة الحر، فمات كثيرون أثناء الطريق.",
     "tags": [
@@ -77,9 +99,12 @@
       "النكبة",
       "الحرب"
     ],
-    "href": "/ar/timeline#lydda-ramle-expulsions-1948"
+    "href": "/ar/timeline#lydda-ramle-expulsions-1948",
+    "lang": "ar",
+    "type": "event"
   },
   {
+    "id": "/ar/timeline#occupation-1967",
     "title": "احتلال الضفة الغربية وقطاع غزة والقدس الشرقية",
     "summary": "بدأ الاحتلال العسكري الإسرائيلي مع ضم القدس الشرقية وفرض نظام طويل من الاستيطان والأوامر العسكرية.",
     "tags": [
@@ -87,9 +112,12 @@
       "الاستيطان",
       "القانون"
     ],
-    "href": "/ar/timeline#occupation-1967"
+    "href": "/ar/timeline#occupation-1967",
+    "lang": "ar",
+    "type": "event"
   },
   {
+    "id": "/ar/timeline#icj-wall-2004",
     "title": "الرأي الاستشاري لمحكمة العدل الدولية حول الجدار",
     "summary": "اعتبرت محكمة العدل الدولية الجدار والنظام المرتبط به مخالفين للقانون الدولي، ودعت إلى تفكيكه وتعويض المتضررين.",
     "tags": [
@@ -97,6 +125,8 @@
       "محكمة-العدل-الدولية",
       "الجدار"
     ],
-    "href": "/ar/timeline#icj-wall-2004"
+    "href": "/ar/timeline#icj-wall-2004",
+    "lang": "ar",
+    "type": "event"
   }
 ]

--- a/public/search.en.json
+++ b/public/search.en.json
@@ -1,5 +1,6 @@
 [
   {
+    "id": "/chapters/001-prologue",
     "title": "Prologue — On Names, Memory, and Return",
     "summary": "Scope, method, sources, and the politics of telling a 4,000-year history.",
     "tags": [
@@ -7,9 +8,12 @@
       "memory",
       "sources"
     ],
-    "href": "/chapters/001-prologue"
+    "href": "/chapters/001-prologue",
+    "lang": "en",
+    "type": "chapter"
   },
   {
+    "id": "/chapters/002-foundations-canaanite-networks",
     "title": "Foundations — Canaanite Urban Networks (-2000 to -1200)",
     "summary": "Canaanite city-states, trade circuits, and material culture in Palestine as groundwork for later continuity and rupture.",
     "tags": [
@@ -18,18 +22,24 @@
       "trade",
       "material-culture"
     ],
-    "href": "/chapters/002-foundations-canaanite-networks"
+    "href": "/chapters/002-foundations-canaanite-networks",
+    "lang": "en",
+    "type": "chapter"
   },
   {
+    "id": "/timeline#canaanite-networks",
     "title": "Canaanite urban networks flourish",
     "summary": "Urban exchange across the Levant consolidates city-states and maritime trade.",
     "tags": [
       "economy",
       "urbanism"
     ],
-    "href": "/timeline#canaanite-networks"
+    "href": "/timeline#canaanite-networks",
+    "lang": "en",
+    "type": "event"
   },
   {
+    "id": "/timeline#balfour-declaration",
     "title": "Balfour Declaration announces British support for a Zionist homeland",
     "summary": "Foreign Secretary Arthur Balfour pledges British backing for a \"national home for the Jewish people\" in Palestine, entrenching imperial control.",
     "tags": [
@@ -37,9 +47,12 @@
       "imperialism",
       "diplomacy"
     ],
-    "href": "/timeline#balfour-declaration"
+    "href": "/timeline#balfour-declaration",
+    "lang": "en",
+    "type": "event"
   },
   {
+    "id": "/timeline#nakba-1948",
     "title": "The Nakba — mass displacement and destruction",
     "summary": "Over 700,000 Palestinians expelled; 400+ villages depopulated or destroyed.",
     "tags": [
@@ -47,9 +60,12 @@
       "violence",
       "war"
     ],
-    "href": "/timeline#nakba-1948"
+    "href": "/timeline#nakba-1948",
+    "lang": "en",
+    "type": "event"
   },
   {
+    "id": "/timeline#arab-revolt-1936-39",
     "title": "The 1936–39 Arab Revolt",
     "summary": "Sustained Palestinian revolt against British colonial rule and Zionist settlement; crushed by massive British repression.",
     "tags": [
@@ -57,9 +73,12 @@
       "british-mandate",
       "colonialism"
     ],
-    "href": "/timeline#arab-revolt-1936-39"
+    "href": "/timeline#arab-revolt-1936-39",
+    "lang": "en",
+    "type": "event"
   },
   {
+    "id": "/timeline#deir-yassin-1948",
     "title": "Deir Yassin massacre",
     "summary": "Irgun and Lehi forces kill scores of Palestinian villagers; event accelerates flight and expulsions during the Nakba.",
     "tags": [
@@ -67,9 +86,12 @@
       "nakba",
       "war"
     ],
-    "href": "/timeline#deir-yassin-1948"
+    "href": "/timeline#deir-yassin-1948",
+    "lang": "en",
+    "type": "event"
   },
   {
+    "id": "/timeline#lydda-ramle-expulsions-1948",
     "title": "Lydda/Ramle expulsions",
     "summary": "Mass expulsions under military orders; tens of thousands forced out in peak heat, many dying en route.",
     "tags": [
@@ -77,9 +99,12 @@
       "nakba",
       "war"
     ],
-    "href": "/timeline#lydda-ramle-expulsions-1948"
+    "href": "/timeline#lydda-ramle-expulsions-1948",
+    "lang": "en",
+    "type": "event"
   },
   {
+    "id": "/timeline#occupation-1967",
     "title": "Occupation of the West Bank, Gaza, East Jerusalem",
     "summary": "Israel’s military occupation begins; annexation of East Jerusalem and a long regime of settlements and military orders follow.",
     "tags": [
@@ -87,9 +112,12 @@
       "settlements",
       "law"
     ],
-    "href": "/timeline#occupation-1967"
+    "href": "/timeline#occupation-1967",
+    "lang": "en",
+    "type": "event"
   },
   {
+    "id": "/timeline#icj-wall-2004",
     "title": "ICJ Wall Advisory Opinion",
     "summary": "International Court of Justice finds the Wall/barrier and related regime contrary to international law; calls for dismantling and reparations.",
     "tags": [
@@ -97,9 +125,12 @@
       "icj",
       "barrier"
     ],
-    "href": "/timeline#icj-wall-2004"
+    "href": "/timeline#icj-wall-2004",
+    "lang": "en",
+    "type": "event"
   },
   {
+    "id": "/timeline#foundations-canaanite-city-states",
     "title": "Canaanite city-states in Palestine",
     "summary": "Urban centers and trade networks in the southern Levant; foundations for later societies.",
     "tags": [
@@ -107,9 +138,12 @@
       "urban",
       "trade"
     ],
-    "href": "/timeline#foundations-canaanite-city-states"
+    "href": "/timeline#foundations-canaanite-city-states",
+    "lang": "en",
+    "type": "event"
   },
   {
+    "id": "/timeline#ottoman-incorporation-1517",
     "title": "Ottoman Incorporation of Palestine",
     "summary": "After the defeat of the Mamluks, the Ottoman administration reorganizes the region, integrating Palestine into imperial provincial structures.",
     "tags": [
@@ -117,9 +151,12 @@
       "administration",
       "governance"
     ],
-    "href": "/timeline#ottoman-incorporation-1517"
+    "href": "/timeline#ottoman-incorporation-1517",
+    "lang": "en",
+    "type": "event"
   },
   {
+    "id": "/timeline#nakba-1947-1949",
     "title": "The Nakba (Catastrophe)",
     "summary": "Mass displacement, village depopulations, and the foundational rupture shaping Palestinian life and exile.",
     "tags": [
@@ -128,9 +165,12 @@
       "war",
       "refugees"
     ],
-    "href": "/timeline#nakba-1947-1949"
+    "href": "/timeline#nakba-1947-1949",
+    "lang": "en",
+    "type": "event"
   },
   {
+    "id": "/timeline#oslo-accords-1993-1995",
     "title": "Oslo Accords",
     "summary": "Interim framework producing fragmented authority under occupation; set conditions for intensified settlement and closure regimes.",
     "tags": [
@@ -140,9 +180,12 @@
       "settlements",
       "closures"
     ],
-    "href": "/timeline#oslo-accords-1993-1995"
+    "href": "/timeline#oslo-accords-1993-1995",
+    "lang": "en",
+    "type": "event"
   },
   {
+    "id": "/timeline#gaza-genocide-2023-present",
     "title": "Genocide in Gaza (2023–Present)",
     "summary": "Large-scale destruction, mass displacement, siege and starvation; ICJ indicated provisional measures in the genocide case; ongoing humanitarian catastrophe.",
     "tags": [
@@ -152,6 +195,8 @@
       "displacement",
       "famine"
     ],
-    "href": "/timeline#gaza-genocide-2023-present"
+    "href": "/timeline#gaza-genocide-2023-present",
+    "lang": "en",
+    "type": "event"
   }
 ]

--- a/scripts/build-search.js
+++ b/scripts/build-search.js
@@ -31,12 +31,15 @@ async function loadChapterDocs() {
     const { data } = matter(raw);
     const tags = normaliseTags(data.tags);
 
+    const hrefEn = `/chapters/${baseSlug}`;
     docs.push({
+      id: hrefEn,
       title: String(data.title ?? baseSlug),
       summary: String(data.summary ?? ''),
       tags,
-      href: `/chapters/${baseSlug}`,
+      href: hrefEn,
       lang: 'en',
+      type: 'chapter',
     });
 
     const arFile = path.join(CHAPTERS_DIR, `${baseSlug}.ar.mdx`);
@@ -52,12 +55,15 @@ async function loadChapterDocs() {
     const tagsAr = arData?.tags ?? data.tags_ar;
 
     if (hasArabic(titleAr)) {
+      const hrefAr = `/ar/chapters/${baseSlug}`;
       docs.push({
+        id: hrefAr,
         title: String(titleAr),
         summary: hasArabic(summaryAr) ? String(summaryAr) : '',
         tags: normaliseTags(tagsAr),
-        href: `/ar/chapters/${baseSlug}`,
+        href: hrefAr,
         lang: 'ar',
+        type: 'chapter',
       });
     }
   }
@@ -92,21 +98,29 @@ async function loadTimelineDocs() {
         title: String(data.title ?? id),
         summary: String(data.summary ?? ''),
         tags: normaliseTags(data.tags),
-        href: `/timeline#${id}`,
-        lang: 'en',
       };
-      docs.push(english);
+      const hrefEn = `/timeline#${id}`;
+      docs.push({
+        id: hrefEn,
+        ...english,
+        href: hrefEn,
+        lang: 'en',
+        type: 'event',
+      });
 
       const titleAr = data.title_ar;
       const summaryAr = data.summary_ar;
       const tagsAr = data.tags_ar;
       if (hasArabic(titleAr) || hasArabic(summaryAr) || (Array.isArray(tagsAr) && tagsAr.some(hasArabic))) {
+        const hrefAr = `/ar/timeline#${id}`;
         docs.push({
+          id: hrefAr,
           title: String(titleAr || data.title || id),
           summary: hasArabic(summaryAr) ? String(summaryAr) : '',
           tags: normaliseTags(tagsAr),
-          href: `/ar/timeline#${id}`,
+          href: hrefAr,
           lang: 'ar',
+          type: 'event',
         });
       }
     }
@@ -130,8 +144,7 @@ async function main() {
   const byLang = { en: [], ar: [] };
   for (const doc of docs) {
     if (doc.lang === 'en' || doc.lang === 'ar') {
-      const { lang, ...rest } = doc;
-      byLang[doc.lang].push(rest);
+      byLang[doc.lang].push(doc);
     }
   }
 

--- a/tests/e2e/home.search.spec.ts
+++ b/tests/e2e/home.search.spec.ts
@@ -5,3 +5,26 @@ test('home search surfaces timeline events', async ({ page }) => {
   await page.getByLabel('Search').fill('Arab');
   await expect(page.getByRole('link', { name: 'The 1936–39 Arab Revolt' })).toBeVisible();
 });
+
+test('search index loads without MiniSearch id errors', async ({ page }) => {
+  const miniSearchErrors: string[] = [];
+
+  page.on('console', (msg) => {
+    if (msg.type() === 'error' && msg.text().includes('MiniSearch: document does not have ID field')) {
+      miniSearchErrors.push(msg.text());
+    }
+  });
+
+  page.on('pageerror', (err) => {
+    if (err.message.includes('MiniSearch: document does not have ID field')) {
+      miniSearchErrors.push(err.message);
+    }
+  });
+
+  await page.goto('/');
+  await page.waitForLoadState('networkidle');
+  await page.getByLabel('Search').fill('history');
+  await expect(page.getByRole('listitem').first()).toBeVisible();
+
+  expect(miniSearchErrors).toHaveLength(0);
+});

--- a/tests/unit/search-normalize.test.ts
+++ b/tests/unit/search-normalize.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { normalizeSearchDocs } from '@/lib/search-normalize';
+
+const noop = () => {};
+
+describe('normalizeSearchDocs', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('derives ids from slug and href when missing', () => {
+    const docs = normalizeSearchDocs(
+      [
+        { slug: 'chapter-1', title: 'Chapter 1', href: '/chapters/chapter-1' },
+        { href: '/timeline#event-1', title: 'Event 1' },
+      ],
+      'en'
+    );
+
+    expect(docs).toHaveLength(2);
+    expect(docs[0]).toMatchObject({
+      id: 'chapter-1',
+      href: '/chapters/chapter-1',
+      title: 'Chapter 1',
+      lang: 'en',
+    });
+    expect(docs[1]).toMatchObject({
+      id: '/timeline#event-1',
+      href: '/timeline#event-1',
+      title: 'Event 1',
+      lang: 'en',
+    });
+  });
+
+  it('skips duplicate ids and warns', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(noop);
+    const docs = normalizeSearchDocs(
+      [
+        { id: 'dup', title: 'One', href: '/chapters/one' },
+        { id: 'dup', title: 'Two', href: '/chapters/two' },
+      ],
+      'en'
+    );
+
+    expect(warn).toHaveBeenCalled();
+    expect(docs).toHaveLength(1);
+    expect(docs[0].href).toBe('/chapters/one');
+  });
+
+  it('falls back to deterministic ids when none provided', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(noop);
+    const docs = normalizeSearchDocs(
+      [
+        { title: 'Untitled doc' },
+        { title: 'Another' },
+      ],
+      'ar'
+    );
+
+    expect(warn).not.toHaveBeenCalledWith('[search] duplicate id, skipping', expect.anything(), expect.anything());
+    expect(docs).toHaveLength(2);
+    expect(docs[0].id).toBe('anon-0');
+    expect(docs[0].href).toBe('/');
+    expect(docs[0].lang).toBe('ar');
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared `SearchDoc` definition and runtime normalizer so MiniSearch always receives stable ids
- emit deterministic ids from the search build script and load them safely in the client
- extend unit and e2e coverage to guard against MiniSearch id errors returning

## Testing
- npm run test:unit *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_6906da19ab98832e9de5a1166874b393