### PR TITLE
feat(seo): expand sitemap coverage for bilingual routes

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,20 +1,77 @@
 // app/sitemap.ts
+import fs from 'node:fs';
+import path from 'node:path';
 import type { MetadataRoute } from 'next';
+import { loadChapterFrontmatter, loadChapterSlugsAr, hasArChapter, hasEnChapter } from '@/lib/loaders.chapters';
 import { loadGazetteer } from '@/lib/loaders.places';
+import { loadTimelineEvents } from '@/lib/loaders.timeline';
+
+function buildLanguageAlternates(enUrl: string, arUrl: string) {
+  return {
+    languages: {
+      en: enUrl,
+      ar: arUrl,
+      'x-default': enUrl,
+    },
+  } satisfies NonNullable<MetadataRoute.Sitemap[number]['alternates']>;
+}
+
+function getFileMtimeIso(filePath: string): string {
+  try {
+    const stats = fs.statSync(filePath);
+    return stats.mtime.toISOString();
+  } catch {
+    return new Date().toISOString();
+  }
+}
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const base = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://palestine.example';
   const now = new Date().toISOString();
 
   const urls: MetadataRoute.Sitemap = [
-    { url: `${base}/`, lastModified: now, alternates: { languages: { en: `${base}/`, ar: `${base}/ar` } } },
-    { url: `${base}/maps`, lastModified: now, alternates: { languages: { en: `${base}/maps`, ar: `${base}/ar/maps` } } },
-    { url: `${base}/timeline`, lastModified: now },
-    { url: `${base}/ar`, lastModified: now, alternates: { languages: { en: `${base}/`, ar: `${base}/ar` } } },
-    { url: `${base}/ar/maps`, lastModified: now, alternates: { languages: { en: `${base}/maps`, ar: `${base}/ar/maps` } } },
-    // Add chapters as you publish them (EN + AR pairs)
-    // { url: `${base}/chapters/001-prologue`, lastModified: now, alternates: { languages: { en: `${base}/chapters/001-prologue`, ar: `${base}/ar/chapters/001-prologue` } } },
+    { url: `${base}/`, lastModified: now, alternates: buildLanguageAlternates(`${base}/`, `${base}/ar`) },
+    { url: `${base}/map`, lastModified: now, alternates: buildLanguageAlternates(`${base}/map`, `${base}/ar/map`) },
+    { url: `${base}/timeline`, lastModified: now, alternates: buildLanguageAlternates(`${base}/timeline`, `${base}/ar/timeline`) },
+    { url: `${base}/ar`, lastModified: now, alternates: buildLanguageAlternates(`${base}/`, `${base}/ar`) },
+    { url: `${base}/ar/map`, lastModified: now, alternates: buildLanguageAlternates(`${base}/map`, `${base}/ar/map`) },
+    { url: `${base}/ar/timeline`, lastModified: now, alternates: buildLanguageAlternates(`${base}/timeline`, `${base}/ar/timeline`) },
   ];
+
+  const chapterSlugs = Array.from(new Set(loadChapterSlugsAr())).sort();
+  for (const slug of chapterSlugs) {
+    const enUrl = `${base}/chapters/${slug}`;
+    const arUrl = `${base}/ar/chapters/${slug}`;
+
+    if (hasEnChapter(slug)) {
+      const { _file } = loadChapterFrontmatter(slug);
+      const lastModified = getFileMtimeIso(_file);
+      urls.push({
+        url: enUrl,
+        lastModified,
+        alternates: buildLanguageAlternates(enUrl, arUrl),
+      });
+    }
+
+    if (hasArChapter(slug)) {
+      const arFile = path.join(process.cwd(), 'content', 'chapters', `${slug}.ar.mdx`);
+      const lastModified = getFileMtimeIso(arFile);
+      urls.push({
+        url: arUrl,
+        lastModified,
+        alternates: buildLanguageAlternates(enUrl, arUrl),
+      });
+    }
+  }
+
+  const timelineEvents = loadTimelineEvents();
+  for (const event of timelineEvents) {
+    const enUrl = `${base}/timeline/${event.id}`;
+    const arUrl = `${base}/ar/timeline/${event.id}`;
+    const alternates = buildLanguageAlternates(enUrl, arUrl);
+    urls.push({ url: enUrl, lastModified: now, alternates });
+    urls.push({ url: arUrl, lastModified: now, alternates });
+  }
 
   // Places (EN + AR paths)
   try {
@@ -23,12 +80,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       urls.push({
         url: `${base}/places/${p.id}`,
         lastModified: now,
-        alternates: { languages: { en: `${base}/places/${p.id}`, ar: `${base}/ar/places/${p.id}` } },
+        alternates: buildLanguageAlternates(`${base}/places/${p.id}`, `${base}/ar/places/${p.id}`),
       });
       urls.push({
         url: `${base}/ar/places/${p.id}`,
         lastModified: now,
-        alternates: { languages: { en: `${base}/places/${p.id}`, ar: `${base}/ar/places/${p.id}` } },
+        alternates: buildLanguageAlternates(`${base}/places/${p.id}`, `${base}/ar/places/${p.id}`),
       });
     }
   } catch {

--- a/tests/e2e/sitemap.spec.ts
+++ b/tests/e2e/sitemap.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from '@playwright/test';
+
+function extractMatches(source: string, pattern: RegExp): string[] {
+  return Array.from(source.match(pattern) ?? []);
+}
+
+test.describe('sitemap.xml', () => {
+  test('includes required routes and excludes deprecated ones', async ({ request }) => {
+    const response = await request.get('/sitemap.xml');
+    expect(response.ok()).toBeTruthy();
+
+    const body = await response.text();
+
+    expect(body).toMatch(/<loc>[^<]+\/map<\/loc>/);
+    expect(body).toMatch(/<loc>[^<]+\/ar\/timeline<\/loc>/);
+
+    const chapterMatches = extractMatches(body, /\/chapters\/[^<]+/g);
+    expect(chapterMatches.length).toBeGreaterThan(0);
+
+    const timelineDetailMatches = extractMatches(body, /https?:\/\/[^<]+\/timeline\/[^<]+/g);
+    const hasDetail = timelineDetailMatches.some((href) => !href.endsWith('/timeline'));
+    expect(hasDetail).toBeTruthy();
+
+    expect(body).not.toContain('/maps');
+  });
+});


### PR DESCRIPTION
## Summary
- replace sitemap map entries with the canonical /map URLs and add x-default alternates for every route
- enumerate chapters and timeline events in the sitemap using chapter file mtimes when available
- add a Playwright check to confirm the sitemap includes the new routes and excludes the deprecated /maps path

## Testing
- npx playwright test tests/e2e/sitemap.spec.ts *(fails: npm 403 when fetching playwright)*

------
https://chatgpt.com/codex/tasks/task_b_6906eb236e908320ba95594e38e2a411