### PR TITLE
fix(map): use canonical /map links across app, update tests/docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ bun dev
 ## Maps
 
 Routes
-- `/maps` — English
-- `/ar/maps` — Arabic (RTL)
+- `/map` — English
+- `/ar/map` — Arabic (RTL)
 
 Features
 - Marker clustering, deep links (`?place=<id>`), click any list item to focus the map, “Reset view”, “Copy link”.

--- a/app/(site)/ar/places/[id]/page.tsx
+++ b/app/(site)/ar/places/[id]/page.tsx
@@ -49,7 +49,7 @@ export default function PlacePageAr({ params }: { params: { id: string } }) {
       ) : null}
 
       <p className="mt-6 text-sm">
-        <a className="underline hover:no-underline" href={`/ar/maps?place=${encodeURIComponent(p.id)}`}>
+        <a className="underline hover:no-underline" href={`/ar/map?place=${encodeURIComponent(p.id)}`}>
           عرض على الخريطة →
         </a>
       </p>

--- a/app/places/[id]/page.tsx
+++ b/app/places/[id]/page.tsx
@@ -50,7 +50,7 @@ export default function PlacePage({ params }: { params: { id: string } }) {
       ) : null}
 
       <p className="mt-6 text-sm">
-        <a className="underline hover:no-underline" href={`/maps?place=${encodeURIComponent(p.id)}`}>
+        <a className="underline hover:no-underline" href={`/map?place=${encodeURIComponent(p.id)}`}>
           View on map →
         </a>
       </p>

--- a/components/TimelineEventDetail.tsx
+++ b/components/TimelineEventDetail.tsx
@@ -160,8 +160,8 @@ export default function TimelineEventDetail({ event, locale = 'en' }: Props) {
                 : null;
               const mapHref = placeId
                 ? isArabic
-                  ? `/ar/maps?place=${encodeURIComponent(placeId)}`
-                  : `/maps?place=${encodeURIComponent(placeId)}`
+                  ? `/ar/map?place=${encodeURIComponent(placeId)}`
+                  : `/map?place=${encodeURIComponent(placeId)}`
                 : null;
 
               return (

--- a/tests/e2e/map.focus.spec.ts
+++ b/tests/e2e/map.focus.spec.ts
@@ -10,7 +10,7 @@ test('map focuses on requested place and copies link', async ({ page }) => {
     });
   });
 
-  await page.goto('/maps?place=gaza');
+  await page.goto('/map?place=gaza');
   await expect(page.getByText('Focused: gaza')).toBeVisible();
 
   await page.getByRole('button', { name: 'Copy a shareable link to this view' }).click();


### PR DESCRIPTION
## Summary
- update place detail pages to link to the canonical /map and /ar/map routes
- align timeline event detail map links with the canonical paths
- refresh map Playwright test and README route docs to use the canonical URLs

## Testing
- npx playwright test tests/e2e/map.focus.spec.ts *(fails: Playwright browsers not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_b_6906ec482610832099b1c71609b245ff