### PR TITLE
feat(seo): add JSON-LD Place schema to place pages (EN + AR)

### DIFF
--- a/app/(site)/ar/places/[id]/page.tsx
+++ b/app/(site)/ar/places/[id]/page.tsx
@@ -1,6 +1,7 @@
 // app/(site)/ar/places/[id]/page.tsx
 import { notFound } from 'next/navigation';
 import type { Metadata } from 'next';
+import JsonLd from '@/components/JsonLd';
 import { loadGazetteer } from '@/lib/loaders.places';
 
 export const dynamic = 'force-static';
@@ -40,6 +41,23 @@ export default function PlacePageAr({ params }: { params: { id: string } }) {
 
   return (
     <main className="mx-auto max-w-3xl px-4 py-12" dir="rtl" lang="ar">
+      <JsonLd
+        id={`ld-place-${p.id}`}
+        data={{
+          '@context': 'https://schema.org',
+          '@type': 'Place',
+          name: p.name,
+          alternateName: p.alt_names?.length ? p.alt_names : undefined,
+          identifier: p.id,
+          url: `/ar/places/${p.id}`,
+          inLanguage: 'ar',
+          geo: {
+            '@type': 'GeoCoordinates',
+            latitude: p.lat,
+            longitude: p.lon,
+          },
+        }}
+      />
       <h1 className="text-2xl font-semibold tracking-tight">{p.name}</h1>
       <p className="mt-2 text-sm text-gray-600">
         {(p.kind as string) ?? 'مكان'} · {p.lat.toFixed(3)}, {p.lon.toFixed(3)}

--- a/app/places/[id]/page.tsx
+++ b/app/places/[id]/page.tsx
@@ -2,6 +2,7 @@
 import Link from 'next/link';
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
+import JsonLd from '@/components/JsonLd';
 import { loadGazetteer } from '@/lib/loaders.places';
 
 export const dynamic = 'force-static';
@@ -42,6 +43,23 @@ export default function PlacePage({ params }: { params: { id: string } }) {
 
   return (
     <main className="mx-auto max-w-3xl px-4 py-12">
+      <JsonLd
+        id={`ld-place-${p.id}`}
+        data={{
+          '@context': 'https://schema.org',
+          '@type': 'Place',
+          name: p.name,
+          alternateName: p.alt_names?.length ? p.alt_names : undefined,
+          identifier: p.id,
+          url: `/places/${p.id}`,
+          inLanguage: 'en',
+          geo: {
+            '@type': 'GeoCoordinates',
+            latitude: p.lat,
+            longitude: p.lon,
+          },
+        }}
+      />
       <h1 className="text-2xl font-semibold tracking-tight">{p.name}</h1>
       <p className="mt-2 text-sm text-gray-600">
         {p.kind ?? 'place'} · {p.lat.toFixed(3)}, {p.lon.toFixed(3)}

--- a/components/JsonLd.tsx
+++ b/components/JsonLd.tsx
@@ -1,0 +1,15 @@
+export default function JsonLd({
+  id,
+  data,
+}: {
+  id: string;
+  data: unknown;
+}) {
+  return (
+    <script
+      id={id}
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+    />
+  );
+}

--- a/tests/e2e/structured-data.place.spec.ts
+++ b/tests/e2e/structured-data.place.spec.ts
@@ -1,0 +1,35 @@
+import type { Page } from '@playwright/test';
+import { expect, test } from '@playwright/test';
+
+async function readJsonLd(page: Page) {
+  const locator = page.locator('script[type="application/ld+json"]');
+  await expect(locator).toHaveCount(1);
+  const text = await locator.first().textContent();
+  return JSON.parse(text ?? '{}');
+}
+
+test.describe('Place structured data', () => {
+  test('includes schema.org Place data on the English page', async ({ page }) => {
+    await page.goto('/places/gaza');
+    const data = await readJsonLd(page);
+
+    expect(data['@type']).toBe('Place');
+    expect(data.inLanguage).toBe('en');
+    expect(data.url).toMatch(/\/places\/gaza$/);
+    expect(data.geo?.['@type']).toBe('GeoCoordinates');
+    expect(typeof data.geo?.latitude).toBe('number');
+    expect(typeof data.geo?.longitude).toBe('number');
+  });
+
+  test('includes schema.org Place data on the Arabic page', async ({ page }) => {
+    await page.goto('/ar/places/gaza');
+    const data = await readJsonLd(page);
+
+    expect(data['@type']).toBe('Place');
+    expect(data.inLanguage).toBe('ar');
+    expect(data.url).toMatch(/\/ar\/places\/gaza$/);
+    expect(data.geo?.['@type']).toBe('GeoCoordinates');
+    expect(typeof data.geo?.latitude).toBe('number');
+    expect(typeof data.geo?.longitude).toBe('number');
+  });
+});


### PR DESCRIPTION
## Summary
- add a reusable JsonLd component for rendering schema.org payloads
- embed Place JSON-LD on English and Arabic place detail pages using existing gazetteer data
- verify structured data through a new Playwright spec covering both locales

## Testing
- npx playwright test tests/e2e/structured-data.place.spec.ts *(fails: Playwright browsers not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_b_6906ef46e97483208caa53ff61f38218