### PR TITLE
feat(seo): add JSON-LD Event schema to timeline event pages (EN + AR)

### DIFF
--- a/app/(site)/ar/timeline/[id]/page.tsx
+++ b/app/(site)/ar/timeline/[id]/page.tsx
@@ -1,6 +1,8 @@
 import { notFound } from 'next/navigation';
 import type { Metadata } from 'next';
 import TimelineEventDetail from '@/components/TimelineEventDetail';
+import JsonLd from '@/components/JsonLd';
+import { loadGazetteer } from '@/lib/loaders.places';
 import { getTimelineEventById, loadTimelineEvents } from '@/lib/loaders.timeline';
 
 export const dynamic = 'force-static';
@@ -47,8 +49,68 @@ export default function TimelineEventPageAr({ params }: { params: { id: string }
   const event = getTimelineEventById(params.id, { locale: 'ar' });
   if (!event) notFound();
 
+  const isArabic = true;
+  const gazetteer = loadGazetteer();
+  const placeIndex = new Map<string, (typeof gazetteer)[number]>();
+  const normalize = (value: string) => value.trim().toLowerCase();
+  for (const place of gazetteer) {
+    placeIndex.set(normalize(place.id), place);
+    placeIndex.set(normalize(place.name), place);
+    for (const alt of place.alt_names ?? []) {
+      placeIndex.set(normalize(String(alt)), place);
+    }
+    if (place.name_ar) {
+      placeIndex.set(normalize(place.name_ar), place);
+    }
+  }
+
+  const locations = (event.places ?? []).map((raw) => {
+    const key = normalize(String(raw));
+    const match = placeIndex.get(key);
+    if (!match) {
+      return {
+        '@type': 'Place',
+        name: String(raw),
+      };
+    }
+
+    const altNames = [match.name_ar, ...(match.alt_names ?? [])].filter(Boolean);
+    const urlBase = isArabic ? '/ar/places' : '/places';
+
+    return {
+      '@type': 'Place',
+      name: match.name,
+      ...(altNames.length ? { alternateName: altNames } : {}),
+      url: `${urlBase}/${match.id}`,
+      geo: {
+        '@type': 'GeoCoordinates',
+        latitude: match.lat,
+        longitude: match.lon,
+      },
+    };
+  });
+
+  const startDate = event.start >= 1 ? `${event.start}-01-01` : undefined;
+  const endDate = typeof event.end === 'number' && event.end >= 1 ? `${event.end}-01-01` : undefined;
+  const eventUrl = isArabic ? `/ar/timeline/${event.id}` : `/timeline/${event.id}`;
+
   return (
     <main className="mx-auto max-w-3xl px-4 py-12 font-arabic" dir="rtl" lang="ar">
+      <JsonLd
+        id={`ld-event-${event.id}`}
+        data={{
+          '@context': 'https://schema.org',
+          '@type': 'Event',
+          name: event.title,
+          description: event.summary || undefined,
+          url: eventUrl,
+          inLanguage: isArabic ? 'ar' : 'en',
+          eventStatus: 'https://schema.org/EventScheduled',
+          ...(startDate ? { startDate } : {}),
+          ...(endDate ? { endDate } : {}),
+          ...(locations.length ? { location: locations } : {}),
+        }}
+      />
       <TimelineEventDetail event={event} locale="ar" />
     </main>
   );

--- a/app/timeline/[id]/page.tsx
+++ b/app/timeline/[id]/page.tsx
@@ -1,6 +1,8 @@
 import { notFound } from 'next/navigation';
 import type { Metadata } from 'next';
 import TimelineEventDetail from '@/components/TimelineEventDetail';
+import JsonLd from '@/components/JsonLd';
+import { loadGazetteer } from '@/lib/loaders.places';
 import { getTimelineEventById, loadTimelineEvents } from '@/lib/loaders.timeline';
 
 export const dynamic = 'force-static';
@@ -46,8 +48,68 @@ export default function TimelineEventPage({ params }: { params: { id: string } }
   const event = getTimelineEventById(params.id, { locale: 'en' });
   if (!event) notFound();
 
+  const isArabic = false;
+  const gazetteer = loadGazetteer();
+  const placeIndex = new Map<string, (typeof gazetteer)[number]>();
+  const normalize = (value: string) => value.trim().toLowerCase();
+  for (const place of gazetteer) {
+    placeIndex.set(normalize(place.id), place);
+    placeIndex.set(normalize(place.name), place);
+    for (const alt of place.alt_names ?? []) {
+      placeIndex.set(normalize(String(alt)), place);
+    }
+    if (place.name_ar) {
+      placeIndex.set(normalize(place.name_ar), place);
+    }
+  }
+
+  const locations = (event.places ?? []).map((raw) => {
+    const key = normalize(String(raw));
+    const match = placeIndex.get(key);
+    if (!match) {
+      return {
+        '@type': 'Place',
+        name: String(raw),
+      };
+    }
+
+    const altNames = [match.name_ar, ...(match.alt_names ?? [])].filter(Boolean);
+    const urlBase = isArabic ? '/ar/places' : '/places';
+
+    return {
+      '@type': 'Place',
+      name: match.name,
+      ...(altNames.length ? { alternateName: altNames } : {}),
+      url: `${urlBase}/${match.id}`,
+      geo: {
+        '@type': 'GeoCoordinates',
+        latitude: match.lat,
+        longitude: match.lon,
+      },
+    };
+  });
+
+  const startDate = event.start >= 1 ? `${event.start}-01-01` : undefined;
+  const endDate = typeof event.end === 'number' && event.end >= 1 ? `${event.end}-01-01` : undefined;
+  const eventUrl = isArabic ? `/ar/timeline/${event.id}` : `/timeline/${event.id}`;
+
   return (
     <main className="mx-auto max-w-3xl px-4 py-12">
+      <JsonLd
+        id={`ld-event-${event.id}`}
+        data={{
+          '@context': 'https://schema.org',
+          '@type': 'Event',
+          name: event.title,
+          description: event.summary || undefined,
+          url: eventUrl,
+          inLanguage: isArabic ? 'ar' : 'en',
+          eventStatus: 'https://schema.org/EventScheduled',
+          ...(startDate ? { startDate } : {}),
+          ...(endDate ? { endDate } : {}),
+          ...(locations.length ? { location: locations } : {}),
+        }}
+      />
       <TimelineEventDetail event={event} locale="en" />
     </main>
   );

--- a/tests/e2e/structured-data.event.spec.ts
+++ b/tests/e2e/structured-data.event.spec.ts
@@ -1,0 +1,50 @@
+import type { Page } from '@playwright/test';
+import { expect, test } from '@playwright/test';
+
+async function readEventJsonLd(page: Page) {
+  const locator = page.locator('script[type="application/ld+json"]');
+  await expect(locator).toHaveCount(1);
+  const text = await locator.first().textContent();
+  return JSON.parse(text ?? '{}');
+}
+
+function expectValidLocations(locations: unknown) {
+  if (!locations) return;
+  const entries = (Array.isArray(locations) ? locations : [locations]).filter(Boolean) as Array<
+    Record<string, unknown>
+  >;
+  for (const entry of entries) {
+    expect(entry['@type']).toBe('Place');
+    const name = entry['name'];
+    const url = entry['url'];
+    const hasName = typeof name === 'string' && name.length > 0;
+    const hasUrl = typeof url === 'string' && url.length > 0;
+    expect(hasName || hasUrl).toBe(true);
+  }
+}
+
+test.describe('Event structured data', () => {
+  test('includes schema.org Event data on the English timeline event', async ({ page }) => {
+    await page.goto('/timeline/arab-revolt-1936-39');
+    const data = await readEventJsonLd(page);
+
+    expect(data['@type']).toBe('Event');
+    expect(data.inLanguage).toBe('en');
+    expect(data.url).toMatch(/\/timeline\/arab-revolt-1936-39$/);
+    expect(data.startDate).toBe('1936-01-01');
+    expect(data.endDate).toBe('1939-01-01');
+    expectValidLocations(data.location);
+  });
+
+  test('includes schema.org Event data on the Arabic timeline event', async ({ page }) => {
+    await page.goto('/ar/timeline/arab-revolt-1936-39');
+    const data = await readEventJsonLd(page);
+
+    expect(data['@type']).toBe('Event');
+    expect(data.inLanguage).toBe('ar');
+    expect(data.url).toMatch(/\/ar\/timeline\/arab-revolt-1936-39$/);
+    expect(data.startDate).toBe('1936-01-01');
+    expect(data.endDate).toBe('1939-01-01');
+    expectValidLocations(data.location);
+  });
+});


### PR DESCRIPTION
## Summary
- embed schema.org Event JSON-LD on English timeline event pages, enriching locations from the gazetteer and omitting BCE dates
- mirror the structured data implementation on Arabic timeline event pages with locale-aware URLs
- cover the new structured data with Playwright checks for English and Arabic event fixtures

## Testing
- npx tsc --noEmit
- npx playwright test tests/e2e/structured-data.event.spec.ts *(fails: browsers not installed in container)*

------
https://chatgpt.com/codex/tasks/task_b_6906f2e595508320ac4adde3e012ca25