### PR TITLE
feat(a11y): label timeline filter chips, improve contrast & focus handling

### DIFF
--- a/components/Timeline.tsx
+++ b/components/Timeline.tsx
@@ -33,7 +33,12 @@ export default function Timeline({
         href: (id: string) => `/timeline/${id}`,
       };
   return (
-    <div className="space-y-8" dir={isArabic ? 'rtl' : 'ltr'}>
+    <section
+      id="timeline-results"
+      aria-live="polite"
+      className="space-y-8"
+      dir={isArabic ? 'rtl' : 'ltr'}
+    >
       {events.map((e) => (
         <div
           key={e.id}
@@ -67,6 +72,6 @@ export default function Timeline({
           </div>
         </div>
       ))}
-    </div>
+    </section>
   );
 }

--- a/components/TimelineFilters.tsx
+++ b/components/TimelineFilters.tsx
@@ -36,11 +36,15 @@ export default function TimelineFilters({
       return {
         placeholder: 'ابحث في الخط الزمني…',
         label: 'ابحث',
+        legend: 'تصفية حسب الحقبة',
+        filterAria: (era: string) => `تصفية حسب الحقبة ${era}`,
       } as const;
     }
     return {
       placeholder: 'Search timeline…',
       label: 'Search',
+      legend: 'Filter by era',
+      filterAria: (era: string) => `Filter by era ${era}`,
     } as const;
   }, [isArabic]);
 
@@ -62,6 +66,9 @@ export default function TimelineFilters({
     update('eras', Array.from(next).join(','));
   }
 
+  const chipBaseClasses =
+    'inline-flex cursor-pointer select-none rounded-full px-3 py-1 text-sm font-medium transition-colors peer-focus-visible:outline-none peer-focus-visible:ring-2 peer-focus-visible:ring-primary-500 peer-focus-visible:ring-offset-2 peer-focus-visible:ring-offset-white dark:peer-focus-visible:ring-offset-gray-900';
+
   return (
     <div className="mb-6 space-y-3" dir={isArabic ? 'rtl' : 'ltr'} role="search">
       <input
@@ -75,21 +82,42 @@ export default function TimelineFilters({
         className={`w-full rounded border px-3 py-2 text-sm ${isArabic ? 'text-right' : ''}`}
       />
 
-      <div className={`flex flex-wrap gap-3 ${isArabic ? 'justify-end' : ''}`}>
-        {eras.map((e) => (
-          <label
-            key={e.id}
-            className={`flex items-center gap-2 text-sm ${isArabic ? 'flex-row-reverse' : ''}`}
-          >
-            <input
-              type="checkbox"
-              checked={selectedEras.has(e.id)}
-              onChange={() => toggleEra(e.id)}
-            />
-            <span>{isArabic ? e.title_ar ?? e.title : e.title}</span>
-          </label>
-        ))}
-      </div>
+      <fieldset className={`m-0 border-0 p-0 ${isArabic ? 'text-right' : ''}`}>
+        <legend className={`mb-2 text-sm font-medium text-gray-700 ${isArabic ? 'text-right' : ''}`}>
+          {t.legend}
+        </legend>
+        <div className={`flex flex-wrap gap-2 ${isArabic ? 'justify-end' : ''}`}>
+          {eras.map((e) => {
+            const id = `timeline-filter-${e.id}`;
+            const label = isArabic ? e.title_ar ?? e.title : e.title;
+            const selected = selectedEras.has(e.id);
+            const stateClasses = selected
+              ? 'bg-primary-600 text-white'
+              : 'bg-gray-300 text-gray-900 hover:bg-gray-400 dark:bg-slate-700 dark:text-white dark:hover:bg-slate-600';
+            return (
+              <div key={e.id} className="flex">
+                <input
+                  type="checkbox"
+                  id={id}
+                  checked={selected}
+                  onChange={() => toggleEra(e.id)}
+                  className="peer sr-only"
+                  aria-label={t.filterAria(label)}
+                />
+                <label
+                  htmlFor={id}
+                  className={`${chipBaseClasses} ${stateClasses}`}
+                  aria-pressed={selected}
+                  aria-controls="timeline-results"
+                  aria-label={t.filterAria(label)}
+                >
+                  {label}
+                </label>
+              </div>
+            );
+          })}
+        </div>
+      </fieldset>
 
       <div aria-live="polite" className="sr-only">
         {announcement}

--- a/tests/e2e/a11y.timeline-filters.spec.ts
+++ b/tests/e2e/a11y.timeline-filters.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from '@playwright/test';
+
+const foundationsHeading = 'Canaanite urban networks flourish';
+const revoltHeading = 'The 1936–39 Arab Revolt';
+
+test('timeline filters expose accessible names and focus styles', async ({ page }) => {
+  await page.goto('/timeline');
+
+  const resultsRegion = page.locator('#timeline-results');
+  await expect(resultsRegion).toBeVisible();
+
+  const foundationsCheckbox = page.getByLabel('Filter by era Foundations');
+  const modernCheckbox = page.getByLabel('Filter by era Modern / Nakba → Present');
+
+  await expect(foundationsCheckbox).toBeVisible();
+  await expect(modernCheckbox).toBeVisible();
+
+  const foundationsLabel = page.locator('label[for="timeline-filter-foundations"]');
+  await expect(foundationsLabel).toHaveAttribute('aria-controls', 'timeline-results');
+  await expect(foundationsLabel).toHaveAttribute('aria-label', 'Filter by era Foundations');
+
+  await foundationsCheckbox.focus();
+  await expect(foundationsCheckbox).toBeFocused();
+
+  const focusShadow = await foundationsLabel.evaluate((el) => getComputedStyle(el).boxShadow);
+  expect(focusShadow).not.toBe('none');
+  expect(focusShadow).not.toBe('rgba(0, 0, 0, 0) 0px 0px 0px 0px');
+
+  const earlyEvent = page.getByRole('heading', { level: 3, name: foundationsHeading });
+  await expect(earlyEvent).toBeVisible();
+
+  await modernCheckbox.check();
+  const modernLabel = page.locator('label[for="timeline-filter-modern"]');
+  await expect(modernLabel).toHaveAttribute('aria-pressed', 'true');
+  await expect(modernLabel).toHaveAttribute(
+    'aria-label',
+    'Filter by era Modern / Nakba → Present'
+  );
+  await expect(page.getByRole('heading', { level: 3, name: revoltHeading })).toBeVisible();
+  await expect(earlyEvent).not.toBeVisible();
+
+  await expect(resultsRegion).toHaveAttribute('aria-live', 'polite');
+
+  await foundationsCheckbox.check();
+  await expect(foundationsLabel).toHaveAttribute('aria-pressed', 'true');
+  await expect(earlyEvent).toBeVisible();
+});

--- a/tests/e2e/timeline.filters.spec.ts
+++ b/tests/e2e/timeline.filters.spec.ts
@@ -5,7 +5,9 @@ test('timeline filters by era checkboxes', async ({ page }) => {
   const foundationsHeading = page.getByRole('heading', { level: 3, name: 'Canaanite urban networks flourish' });
   await expect(foundationsHeading).toBeVisible();
 
-  await page.getByRole('checkbox', { name: 'Modern / Nakba → Present' }).check();
+  await page
+    .getByRole('checkbox', { name: 'Filter by era Modern / Nakba → Present' })
+    .check();
 
   await expect(foundationsHeading).not.toBeVisible();
   await expect(page.getByRole('heading', { level: 3, name: 'The 1936–39 Arab Revolt' })).toBeVisible();


### PR DESCRIPTION
## Summary
- wrap the timeline filters in a semantic fieldset/legend and expose accessible names, pressed state, and focus rings for each chip
- raise contrast for unselected chips and connect the controls to the timeline results live region
- mark the results list as `aria-live` and add a dedicated Playwright spec that checks labeling, pressed state, and focus management

## Testing
- npx playwright test tests/e2e/a11y.timeline-filters.spec.ts *(fails: Playwright browsers not installed in container)*

------
https://chatgpt.com/codex/tasks/task_b_6906f4d6af34832081f3f9c330424c1f