### PR TITLE
feat(a11y): add global “Skip to main content” and landmark ids

### DIFF
--- a/app/(site)/ar/chapters/[slug]/page.tsx
+++ b/app/(site)/ar/chapters/[slug]/page.tsx
@@ -136,7 +136,7 @@ export default async function Page({ params }: Props) {
   return (
     <>
       <JsonLd id={`ld-article-${params.slug}`} data={articleLd} />
-      <main className="mx-auto max-w-3xl px-4 py-12">
+      <main id="main" tabIndex={-1} className="mx-auto max-w-3xl px-4 py-12">
         <h1 className="text-2xl font-semibold tracking-tight font-arabic">{title}</h1>
 
         {summary && (

--- a/app/(site)/ar/layout.tsx
+++ b/app/(site)/ar/layout.tsx
@@ -12,6 +12,12 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="ar" dir="rtl">
       <body className="font-arabic bg-white text-gray-900">
+        <a
+          href="#main"
+          className="sr-only focus:not-sr-only focus:absolute rtl:focus:right-3 ltr:focus:left-3 focus:top-3 focus:z-50 rounded bg-white px-3 py-1 text-sm shadow"
+        >
+          تجاوز إلى المحتوى
+        </a>
         <header className="border-b">
           <div className="mx-auto flex max-w-4xl justify-start px-4 py-3" dir="rtl">
             <Suspense fallback={<span className="text-sm text-gray-400">…</span>}>

--- a/app/(site)/ar/map/page.tsx
+++ b/app/(site)/ar/map/page.tsx
@@ -24,7 +24,7 @@ export default function MapsPageAr({
   const enHref = initialFocusId ? `/map?place=${initialFocusId}` : '/map';
 
   return (
-    <main className="mx-auto max-w-3xl px-4 py-12" dir="rtl" lang="ar">
+    <main id="main" tabIndex={-1} className="mx-auto max-w-3xl px-4 py-12" dir="rtl" lang="ar">
       <h1 className="text-2xl font-semibold tracking-tight font-arabic">الأماكن</h1>
 
       <div className="mt-4">

--- a/app/(site)/ar/page.tsx
+++ b/app/(site)/ar/page.tsx
@@ -19,7 +19,7 @@ export const metadata = {
 
 export default function Page() {
   return (
-    <main className="mx-auto max-w-3xl px-4 py-12" dir="rtl" lang="ar">
+    <main id="main" tabIndex={-1} className="mx-auto max-w-3xl px-4 py-12" dir="rtl" lang="ar">
       <header className="mb-8">
         <h1 className="text-3xl font-semibold tracking-tight font-arabic">فلسطين</h1>
         <p className="mt-2 text-base text-gray-600 font-arabic">

--- a/app/(site)/ar/places/[id]/page.tsx
+++ b/app/(site)/ar/places/[id]/page.tsx
@@ -40,7 +40,7 @@ export default function PlacePageAr({ params }: { params: { id: string } }) {
   const enHref = `/places/${p.id}`;
 
   return (
-    <main className="mx-auto max-w-3xl px-4 py-12" dir="rtl" lang="ar">
+    <main id="main" tabIndex={-1} className="mx-auto max-w-3xl px-4 py-12" dir="rtl" lang="ar">
       <JsonLd
         id={`ld-place-${p.id}`}
         data={{

--- a/app/(site)/ar/timeline/[id]/page.tsx
+++ b/app/(site)/ar/timeline/[id]/page.tsx
@@ -95,7 +95,7 @@ export default function TimelineEventPageAr({ params }: { params: { id: string }
   const eventUrl = isArabic ? `/ar/timeline/${event.id}` : `/timeline/${event.id}`;
 
   return (
-    <main className="mx-auto max-w-3xl px-4 py-12 font-arabic" dir="rtl" lang="ar">
+    <main id="main" tabIndex={-1} className="mx-auto max-w-3xl px-4 py-12 font-arabic" dir="rtl" lang="ar">
       <JsonLd
         id={`ld-event-${event.id}`}
         data={{

--- a/app/(site)/ar/timeline/page.tsx
+++ b/app/(site)/ar/timeline/page.tsx
@@ -25,7 +25,7 @@ export default function Page({
   const events = filterTimeline({ q, eras, locale: 'ar' });
 
   return (
-    <main className="mx-auto max-w-3xl px-4 py-12 font-arabic" dir="rtl" lang="ar">
+    <main id="main" tabIndex={-1} className="mx-auto max-w-3xl px-4 py-12 font-arabic" dir="rtl" lang="ar">
       <h1 className="text-2xl font-semibold tracking-tight">الخط الزمني</h1>
       <Suspense
         fallback={

--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -14,7 +14,7 @@ export const metadata = {
 
 export default function Page() {
   return (
-    <main className="mx-auto max-w-3xl px-4 py-12">
+    <main id="main" tabIndex={-1} className="mx-auto max-w-3xl px-4 py-12">
       <header className="mb-8">
         <h1 className="text-3xl font-semibold tracking-tight">Palestine</h1>
         <p className="mt-2 text-base text-gray-600">

--- a/app/chapters/[slug]/page.tsx
+++ b/app/chapters/[slug]/page.tsx
@@ -96,7 +96,7 @@ export default async function Page({ params }: Props) {
   return (
     <>
       <JsonLd id={`ld-article-${params.slug}`} data={articleLd} />
-      <main className="mx-auto max-w-3xl px-4 py-12">
+      <main id="main" tabIndex={-1} className="mx-auto max-w-3xl px-4 py-12">
         <h1 className="text-2xl font-semibold tracking-tight">{meta.title}</h1>
 
         <div className="mt-2 text-sm text-gray-600">

--- a/app/chapters/page.tsx
+++ b/app/chapters/page.tsx
@@ -5,7 +5,7 @@ export default function Page() {
   const items = slugs.map((slug) => ({ slug, meta: loadChapterFrontmatter(slug) }));
 
   return (
-    <main className="mx-auto max-w-3xl px-4 py-12">
+    <main id="main" tabIndex={-1} className="mx-auto max-w-3xl px-4 py-12">
       <h1 className="text-2xl font-semibold tracking-tight">Chapters</h1>
       <ul className="mt-6 space-y-4">
         {items.map(({ slug, meta }) => (

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -33,6 +33,12 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
       <body className={`${inter.variable} ${naskh.variable} font-sans`}>
+        <a
+          href="#main"
+          className="sr-only focus:not-sr-only focus:absolute focus:left-3 focus:top-3 focus:z-50 rounded bg-white px-3 py-1 text-sm shadow"
+        >
+          Skip to main content
+        </a>
         {children}
       </body>
     </html>

--- a/app/map/page.tsx
+++ b/app/map/page.tsx
@@ -25,7 +25,7 @@ export default function MapsPage({
   const arHref = initialFocusId ? `/ar/map?place=${initialFocusId}` : '/ar/map';
 
   return (
-    <main className="mx-auto max-w-3xl px-4 py-12">
+    <main id="main" tabIndex={-1} className="mx-auto max-w-3xl px-4 py-12">
       <h1 className="text-2xl font-semibold tracking-tight">Places</h1>
       <p className="mt-2 text-sm text-gray-600">
         Loaded from <code>data/gazetteer.json</code>

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link';
 
 export default function NotFound() {
   return (
-    <main className="min-h-screen flex flex-col items-center justify-center gap-6 p-8 text-center">
+    <main id="main" tabIndex={-1} className="min-h-screen flex flex-col items-center justify-center gap-6 p-8 text-center">
       <h1 className="text-4xl font-bold tracking-tight">404 — Page not found</h1>
       <p className="max-w-xl text-base text-gray-600">
         We couldn’t find the page you were looking for. It might have been moved or removed.

--- a/app/places/[id]/page.tsx
+++ b/app/places/[id]/page.tsx
@@ -42,7 +42,7 @@ export default function PlacePage({ params }: { params: { id: string } }) {
   const arHref = `/ar/places/${p.id}`;
 
   return (
-    <main className="mx-auto max-w-3xl px-4 py-12">
+    <main id="main" tabIndex={-1} className="mx-auto max-w-3xl px-4 py-12">
       <JsonLd
         id={`ld-place-${p.id}`}
         data={{

--- a/app/timeline/[id]/page.tsx
+++ b/app/timeline/[id]/page.tsx
@@ -94,7 +94,7 @@ export default function TimelineEventPage({ params }: { params: { id: string } }
   const eventUrl = isArabic ? `/ar/timeline/${event.id}` : `/timeline/${event.id}`;
 
   return (
-    <main className="mx-auto max-w-3xl px-4 py-12">
+    <main id="main" tabIndex={-1} className="mx-auto max-w-3xl px-4 py-12">
       <JsonLd
         id={`ld-event-${event.id}`}
         data={{

--- a/app/timeline/page.tsx
+++ b/app/timeline/page.tsx
@@ -25,7 +25,7 @@ export default function Page({
   const events = filterTimeline({ q, eras, locale: 'en' });
 
   return (
-    <main className="mx-auto max-w-3xl px-4 py-12">
+    <main id="main" tabIndex={-1} className="mx-auto max-w-3xl px-4 py-12">
       <h1 className="text-2xl font-semibold tracking-tight">Timeline</h1>
       <Suspense
         fallback={<div className="mb-6 h-24 animate-pulse rounded border" aria-hidden="true" />}

--- a/tests/e2e/a11y.skip-link.spec.ts
+++ b/tests/e2e/a11y.skip-link.spec.ts
@@ -1,0 +1,21 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Skip link', () => {
+  test('English: shows skip link and navigates to #main', async ({ page }) => {
+    await page.goto('/');
+    await page.keyboard.press('Tab');
+    const skip = page.getByRole('link', { name: 'Skip to main content' });
+    await expect(skip).toBeVisible();
+    await skip.press('Enter');
+    await expect(page).toHaveURL(/#main$/);
+  });
+
+  test('Arabic: shows skip link and navigates to #main', async ({ page }) => {
+    await page.goto('/ar');
+    await page.keyboard.press('Tab');
+    const skip = page.getByRole('link', { name: 'تجاوز إلى المحتوى' });
+    await expect(skip).toBeVisible();
+    await skip.press('Enter');
+    await expect(page).toHaveURL(/\/ar#main$/);
+  });
+});


### PR DESCRIPTION
## Summary
- add a reveal-on-focus skip link to the English root layout and the Arabic segment layout
- assign a shared `id="main"` and `tabIndex={-1}` to every `<main>` landmark across English and Arabic routes
- cover the skip link behaviour with a focused Playwright e2e test for both locales

## Testing
- npx playwright test tests/e2e/a11y.skip-link.spec.ts *(fails: Playwright browsers not installed in CI environment)*

------
https://chatgpt.com/codex/tasks/task_b_6906f7b20ed483208728d29cd4fdd9b3