### PR TITLE
feat(a11y): use real buttons for map place list items (EN + AR)

### DIFF
--- a/components/MapsPageClient.ar.tsx
+++ b/components/MapsPageClient.ar.tsx
@@ -145,32 +145,38 @@ export default function MapsPageClientAr({
         ) : null}
       </div>
 
-      <ul className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2">
+      <h2 className="sr-only" id="map-places-heading">
+        قائمة الأماكن
+      </h2>
+      <ul
+        aria-labelledby="map-places-heading"
+        className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2"
+      >
         {places.map((p) => {
           const focused = p.id === focusId;
           return (
             <li
               key={p.id}
-              className={`rounded border p-3 cursor-pointer ${focused ? 'bg-yellow-50 border-yellow-300' : 'hover:bg-gray-50'}`}
-              onClick={() => setFocusId(p.id)}
-              role="button"
-              tabIndex={0}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' || e.key === ' ') setFocusId(p.id);
-              }}
-              aria-pressed={focused}
-              aria-label={`التركيز على ${displayName(p)} في الخريطة`}
-              title="انقر للتركيز على الخريطة"
+              className={`rounded border p-3 ${focused ? 'bg-yellow-50 border-yellow-300' : 'hover:bg-gray-50'}`}
             >
-              <div className="font-medium">{displayName(p)}</div>
-              <div className="text-sm text-gray-600">
-                {formatKindAr(p.kind)} · {p.lat.toFixed(3)}, {p.lon.toFixed(3)}
-              </div>
-              {p.alt_names?.length ? (
-                <div className="text-xs text-gray-500 mt-1">
-                  أسماء أخرى: {p.alt_names.join('، ')}
+              <button
+                type="button"
+                className="block w-full text-left"
+                onClick={() => setFocusId(p.id)}
+                aria-pressed={focused}
+                aria-label={`التركيز على ${displayName(p)} في الخريطة`}
+                title="انقر للتركيز على الخريطة"
+              >
+                <div className="font-medium">{displayName(p)}</div>
+                <div className="text-sm text-gray-600">
+                  {formatKindAr(p.kind)} · {p.lat.toFixed(3)}, {p.lon.toFixed(3)}
                 </div>
-              ) : null}
+                {p.alt_names?.length ? (
+                  <div className="text-xs text-gray-500 mt-1">
+                    أسماء أخرى: {p.alt_names.join('، ')}
+                  </div>
+                ) : null}
+              </button>
             </li>
           );
         })}

--- a/components/MapsPageClient.tsx
+++ b/components/MapsPageClient.tsx
@@ -124,32 +124,38 @@ export default function MapsPageClient({
         ) : null}
       </div>
 
-      <ul className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2">
+      <h2 className="sr-only" id="map-places-heading">
+        Places list
+      </h2>
+      <ul
+        aria-labelledby="map-places-heading"
+        className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2"
+      >
         {places.map((p) => {
           const focused = p.id === focusId;
           return (
             <li
               key={p.id}
-              className={`rounded border p-3 cursor-pointer ${focused ? 'bg-yellow-50 border-yellow-300' : 'hover:bg-gray-50'}`}
-              onClick={() => setFocusId(p.id)}
-              role="button"
-              tabIndex={0}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' || e.key === ' ') setFocusId(p.id);
-              }}
-              aria-pressed={focused}
-              aria-label={`Focus map on ${p.name}`}
-              title="Click to focus on the map"
+              className={`rounded border p-3 ${focused ? 'bg-yellow-50 border-yellow-300' : 'hover:bg-gray-50'}`}
             >
-              <div className="font-medium">{p.name}</div>
-              <div className="text-sm text-gray-600">
-                {formatKind(p.kind)} · {p.lat.toFixed(3)}, {p.lon.toFixed(3)}
-              </div>
-              {p.alt_names?.length ? (
-                <div className="text-xs text-gray-500 mt-1">
-                  Also known as: {p.alt_names.join(', ')}
+              <button
+                type="button"
+                className="block w-full text-left"
+                onClick={() => setFocusId(p.id)}
+                aria-pressed={focused}
+                aria-label={`Focus map on ${p.name}`}
+                title="Click to focus on the map"
+              >
+                <div className="font-medium">{p.name}</div>
+                <div className="text-sm text-gray-600">
+                  {formatKind(p.kind)} · {p.lat.toFixed(3)}, {p.lon.toFixed(3)}
                 </div>
-              ) : null}
+                {p.alt_names?.length ? (
+                  <div className="text-xs text-gray-500 mt-1">
+                    Also known as: {p.alt_names.join(', ')}
+                  </div>
+                ) : null}
+              </button>
             </li>
           );
         })}

--- a/tests/e2e/a11y.map-list-buttons.spec.ts
+++ b/tests/e2e/a11y.map-list-buttons.spec.ts
@@ -1,0 +1,31 @@
+import { expect, test } from '@playwright/test';
+
+test('english map place buttons support keyboard activation', async ({ page }) => {
+  await page.goto('/map');
+
+  const gazaButton = page.getByRole('button', { name: 'Focus map on Gaza' });
+  await gazaButton.press('Enter');
+  await expect(page.getByText('Focused: gaza')).toBeVisible();
+  await expect(gazaButton).toHaveAttribute('aria-pressed', 'true');
+
+  const jaffaButton = page.getByRole('button', { name: 'Focus map on Jaffa' });
+  await jaffaButton.press(' ');
+  await expect(page.getByText('Focused: jaffa')).toBeVisible();
+  await expect(jaffaButton).toHaveAttribute('aria-pressed', 'true');
+  await expect(gazaButton).toHaveAttribute('aria-pressed', 'false');
+});
+
+test('arabic map place buttons expose pressed state for keyboard users', async ({ page }) => {
+  await page.goto('/ar/map');
+
+  const gazaButton = page.getByRole('button', { name: 'التركيز على غزة في الخريطة' });
+  await gazaButton.press('Enter');
+  await expect(page.getByText('المركّز: gaza')).toBeVisible();
+  await expect(gazaButton).toHaveAttribute('aria-pressed', 'true');
+
+  const jaffaButton = page.getByRole('button', { name: 'التركيز على يافا في الخريطة' });
+  await jaffaButton.press(' ');
+  await expect(page.getByText('المركّز: jaffa')).toBeVisible();
+  await expect(jaffaButton).toHaveAttribute('aria-pressed', 'true');
+  await expect(gazaButton).toHaveAttribute('aria-pressed', 'false');
+});


### PR DESCRIPTION
## Summary
- replace the faux button list items in the English and Arabic map clients with real buttons and screen reader headings
- preserve the pressed state and existing labelling while keeping the visual treatment intact
- add Playwright coverage to confirm keyboard activation updates the focused place and aria-pressed state in both locales

## Testing
- npx playwright test tests/e2e/a11y.map-list-buttons.spec.ts *(fails: browser binaries are not installed in CI image)*

------
https://chatgpt.com/codex/tasks/task_b_6906fb3112148320987dfd09b8b915cd