### PR TITLE
feat(seo): per-page Open Graph images (chapters, events, places) with locale support

### DIFF
--- a/app/(site)/ar/chapters/[slug]/opengraph-image.tsx
+++ b/app/(site)/ar/chapters/[slug]/opengraph-image.tsx
@@ -1,0 +1,48 @@
+import { ImageResponse } from 'next/og';
+import { loadChapterFrontmatterAr } from '@/lib/loaders.chapters';
+
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+export default function OgImage({ params }: { params: { slug: string } }) {
+  let title = 'فلسطين: الفصل';
+  let summary: string | undefined;
+
+  try {
+    const { frontmatter } = loadChapterFrontmatterAr(params.slug);
+    title = frontmatter.title_ar?.trim() || frontmatter.title || title;
+    summary = frontmatter.summary_ar?.trim() || frontmatter.summary?.trim() || summary;
+  } catch (error) {
+    // fall through to fallback title
+  }
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          background: '#0b0b0b',
+          color: '#fdfdfd',
+          padding: 64,
+          fontFamily: 'Inter, system-ui, sans-serif',
+          backgroundImage: 'radial-gradient(circle at 100% 100%, #222 0%, #0b0b0b 70%)',
+          direction: 'rtl',
+          textAlign: 'right',
+        }}
+      >
+        <div style={{ opacity: 0.7, fontSize: 22, letterSpacing: 2 }}>فصل • فلسطين</div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 24, maxWidth: 920 }}>
+          <div style={{ fontSize: 64, fontWeight: 700, lineHeight: 1.2 }}>{title}</div>
+          {summary ? (
+            <div style={{ fontSize: 30, lineHeight: 1.4, opacity: 0.85 }}>{summary}</div>
+          ) : null}
+        </div>
+      </div>
+    ),
+    size
+  );
+}

--- a/app/(site)/ar/chapters/[slug]/page.tsx
+++ b/app/(site)/ar/chapters/[slug]/page.tsx
@@ -25,7 +25,6 @@ export function generateMetadata({ params }: { params: { slug: string } }) {
   }
   const { frontmatter: arFm, isFallback } = loadChapterFrontmatterAr(params.slug);
   const enFm = hasEn ? loadChapterFrontmatter(params.slug) : null;
-  const url = process.env.NEXT_PUBLIC_SITE_URL ?? '';
   const title = arFm.title ?? enFm?.title ?? params.slug;
   const summary = arFm.summary ?? enFm?.summary;
   const canonical = `/ar/chapters/${params.slug}`;
@@ -44,7 +43,7 @@ export function generateMetadata({ params }: { params: { slug: string } }) {
     openGraph: {
       title: isFallback ? `${title} (English)` : title,
       description: summary,
-      images: url ? [`${url}/opengraph-image`] : undefined,
+      images: [`/ar/chapters/${params.slug}/opengraph-image`],
       url: canonical,
     },
   };

--- a/app/(site)/ar/places/[id]/opengraph-image.tsx
+++ b/app/(site)/ar/places/[id]/opengraph-image.tsx
@@ -1,0 +1,47 @@
+import { ImageResponse } from 'next/og';
+import { loadGazetteer } from '@/lib/loaders.places';
+
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+function formatCoords(lat: number, lon: number): string {
+  return `${lat.toFixed(3)}, ${lon.toFixed(3)}`;
+}
+
+export default function OgImage({ params }: { params: { id: string } }) {
+  let title = 'مكان في فلسطين';
+  let detail = 'المكان • فلسطين';
+
+  const place = loadGazetteer().find((entry) => entry.id === params.id);
+  if (place) {
+    title = place.name_ar?.trim() || place.name || title;
+    detail = `المكان • ${formatCoords(place.lat, place.lon)}`;
+  }
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          background: '#0b0b0b',
+          color: '#fdfdfd',
+          padding: 64,
+          fontFamily: 'Inter, system-ui, sans-serif',
+          backgroundImage: 'radial-gradient(circle at 100% 100%, #222 0%, #0b0b0b 70%)',
+          direction: 'rtl',
+          textAlign: 'right',
+        }}
+      >
+        <div style={{ opacity: 0.7, fontSize: 24, letterSpacing: 2 }}>{detail}</div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 16, maxWidth: 920 }}>
+          <div style={{ fontSize: 72, fontWeight: 700, lineHeight: 1.1 }}>{title}</div>
+        </div>
+      </div>
+    ),
+    size
+  );
+}

--- a/app/(site)/ar/places/[id]/page.tsx
+++ b/app/(site)/ar/places/[id]/page.tsx
@@ -27,7 +27,7 @@ export async function generateMetadata({
     openGraph: {
       title: p.name,
       description: `${p.kind ?? 'مكان'} · ${p.lat}, ${p.lon}`,
-      images: ['/opengraph-image'],
+      images: [`/ar/places/${p.id}/opengraph-image`],
       url: `/ar/places/${p.id}`,
     },
   };

--- a/app/(site)/ar/timeline/[id]/opengraph-image.tsx
+++ b/app/(site)/ar/timeline/[id]/opengraph-image.tsx
@@ -1,0 +1,59 @@
+import { ImageResponse } from 'next/og';
+import { getTimelineEventById } from '@/lib/loaders.timeline';
+
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+function formatYearRange(start: number, end: number | null): string | null {
+  if (start >= 1) {
+    if (typeof end === 'number' && end >= 1 && end !== start) {
+      return `${start}\u2013${end}`;
+    }
+    return `${start}`;
+  }
+  return null;
+}
+
+export default function OgImage({ params }: { params: { id: string } }) {
+  let title = 'الخط الزمني لفلسطين';
+  let summary: string | undefined;
+  let detail = 'حدث على الخط الزمني';
+
+  const event = getTimelineEventById(params.id, { locale: 'ar' });
+  if (event) {
+    title = event.title || title;
+    summary = event.summary?.trim() || undefined;
+    const range = formatYearRange(event.start, event.end);
+    detail = range ? `الخط الزمني • ${range}` : detail;
+  }
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          background: '#0b0b0b',
+          color: '#fdfdfd',
+          padding: 64,
+          fontFamily: 'Inter, system-ui, sans-serif',
+          backgroundImage: 'radial-gradient(circle at 100% 100%, #222 0%, #0b0b0b 70%)',
+          direction: 'rtl',
+          textAlign: 'right',
+        }}
+      >
+        <div style={{ opacity: 0.7, fontSize: 24, letterSpacing: 2 }}>{detail}</div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 24, maxWidth: 920 }}>
+          <div style={{ fontSize: 64, fontWeight: 700, lineHeight: 1.2 }}>{title}</div>
+          {summary ? (
+            <div style={{ fontSize: 30, lineHeight: 1.4, opacity: 0.85 }}>{summary}</div>
+          ) : null}
+        </div>
+      </div>
+    ),
+    size
+  );
+}

--- a/app/(site)/ar/timeline/[id]/page.tsx
+++ b/app/(site)/ar/timeline/[id]/page.tsx
@@ -38,6 +38,7 @@ export function generateMetadata({
     openGraph: {
       title: event.title,
       description: event.summary ?? undefined,
+      images: [`/ar/timeline/${event.id}/opengraph-image`],
       url: `/ar/timeline/${event.id}`,
       locale: 'ar',
       type: 'article',

--- a/app/chapters/[slug]/opengraph-image.tsx
+++ b/app/chapters/[slug]/opengraph-image.tsx
@@ -1,0 +1,44 @@
+import { ImageResponse } from 'next/og';
+import { hasEnChapter, loadChapterFrontmatter } from '@/lib/loaders.chapters';
+
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+export default function OgImage({ params }: { params: { slug: string } }) {
+  let title = 'Palestine: Chapter';
+  let summary: string | undefined;
+
+  if (hasEnChapter(params.slug)) {
+    const frontmatter = loadChapterFrontmatter(params.slug);
+    title = frontmatter.title ?? title;
+    summary = frontmatter.summary?.trim() || undefined;
+  }
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          background: '#0b0b0b',
+          color: '#fdfdfd',
+          padding: 64,
+          fontFamily: 'Inter, system-ui, sans-serif',
+          backgroundImage: 'radial-gradient(circle at 0% 100%, #222 0%, #0b0b0b 70%)',
+        }}
+      >
+        <div style={{ opacity: 0.7, fontSize: 22, letterSpacing: 2 }}>CHAPTER • PALESTINE</div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 24, maxWidth: 920 }}>
+          <div style={{ fontSize: 64, fontWeight: 700, lineHeight: 1.2 }}>{title}</div>
+          {summary ? (
+            <div style={{ fontSize: 30, lineHeight: 1.4, opacity: 0.85 }}>{summary}</div>
+          ) : null}
+        </div>
+      </div>
+    ),
+    size
+  );
+}

--- a/app/chapters/[slug]/page.tsx
+++ b/app/chapters/[slug]/page.tsx
@@ -20,7 +20,6 @@ export function generateMetadata({ params }: { params: { slug: string } }) {
     notFound();
   }
   const fm = loadChapterFrontmatter(params.slug);
-  const url = process.env.NEXT_PUBLIC_SITE_URL ?? '';
   const ar = hasArChapter(params.slug);
   const canonical = `/chapters/${params.slug}`;
   const languages: Record<string, string> = {
@@ -40,7 +39,7 @@ export function generateMetadata({ params }: { params: { slug: string } }) {
     openGraph: {
       title: fm.title,
       description: fm.summary,
-      images: url ? [`${url}/opengraph-image`] : undefined,
+      images: [`/chapters/${params.slug}/opengraph-image`],
       url: canonical,
     },
   };

--- a/app/places/[id]/opengraph-image.tsx
+++ b/app/places/[id]/opengraph-image.tsx
@@ -1,0 +1,45 @@
+import { ImageResponse } from 'next/og';
+import { loadGazetteer } from '@/lib/loaders.places';
+
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+function formatCoords(lat: number, lon: number): string {
+  return `${lat.toFixed(3)}, ${lon.toFixed(3)}`;
+}
+
+export default function OgImage({ params }: { params: { id: string } }) {
+  let title = 'Palestine Place';
+  let detail = 'PLACE • فلسطين';
+
+  const place = loadGazetteer().find((entry) => entry.id === params.id);
+  if (place) {
+    title = place.name || title;
+    detail = `PLACE • ${formatCoords(place.lat, place.lon)}`;
+  }
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          background: '#0b0b0b',
+          color: '#fdfdfd',
+          padding: 64,
+          fontFamily: 'Inter, system-ui, sans-serif',
+          backgroundImage: 'radial-gradient(circle at 0% 100%, #222 0%, #0b0b0b 70%)',
+        }}
+      >
+        <div style={{ opacity: 0.7, fontSize: 24, letterSpacing: 2 }}>{detail}</div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 16, maxWidth: 920 }}>
+          <div style={{ fontSize: 72, fontWeight: 700, lineHeight: 1.1 }}>{title}</div>
+        </div>
+      </div>
+    ),
+    size
+  );
+}

--- a/app/places/[id]/page.tsx
+++ b/app/places/[id]/page.tsx
@@ -29,7 +29,7 @@ export async function generateMetadata({
     openGraph: {
       title: p.name,
       description: `${p.kind ?? 'place'} · ${p.lat}, ${p.lon}`,
-      images: ['/opengraph-image'],
+      images: [`/places/${p.id}/opengraph-image`],
       url: `/places/${p.id}`,
     },
   };

--- a/app/timeline/[id]/opengraph-image.tsx
+++ b/app/timeline/[id]/opengraph-image.tsx
@@ -1,0 +1,57 @@
+import { ImageResponse } from 'next/og';
+import { getTimelineEventById } from '@/lib/loaders.timeline';
+
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+function formatYearRange(start: number, end: number | null): string | null {
+  if (start >= 1) {
+    if (typeof end === 'number' && end >= 1 && end !== start) {
+      return `${start}\u2013${end}`;
+    }
+    return `${start}`;
+  }
+  return null;
+}
+
+export default function OgImage({ params }: { params: { id: string } }) {
+  let title = 'Palestine Timeline';
+  let summary: string | undefined;
+  let detail = 'TIMELINE EVENT';
+
+  const event = getTimelineEventById(params.id, { locale: 'en' });
+  if (event) {
+    title = event.title || title;
+    summary = event.summary?.trim() || undefined;
+    const range = formatYearRange(event.start, event.end);
+    detail = range ? `TIMELINE • ${range}` : 'TIMELINE EVENT';
+  }
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          background: '#0b0b0b',
+          color: '#fdfdfd',
+          padding: 64,
+          fontFamily: 'Inter, system-ui, sans-serif',
+          backgroundImage: 'radial-gradient(circle at 0% 100%, #222 0%, #0b0b0b 70%)',
+        }}
+      >
+        <div style={{ opacity: 0.7, fontSize: 24, letterSpacing: 2 }}>{detail}</div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 24, maxWidth: 920 }}>
+          <div style={{ fontSize: 64, fontWeight: 700, lineHeight: 1.2 }}>{title}</div>
+          {summary ? (
+            <div style={{ fontSize: 30, lineHeight: 1.4, opacity: 0.85 }}>{summary}</div>
+          ) : null}
+        </div>
+      </div>
+    ),
+    size
+  );
+}

--- a/app/timeline/[id]/page.tsx
+++ b/app/timeline/[id]/page.tsx
@@ -38,6 +38,7 @@ export function generateMetadata({
     openGraph: {
       title: event.title,
       description: event.summary ?? undefined,
+      images: [`/timeline/${event.id}/opengraph-image`],
       url: `/timeline/${event.id}`,
       type: 'article',
     },

--- a/tests/e2e/og-images.spec.ts
+++ b/tests/e2e/og-images.spec.ts
@@ -1,0 +1,21 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Open Graph image routes', () => {
+  test('serves chapter image', async ({ request }) => {
+    const response = await request.get('/chapters/001-prologue/opengraph-image');
+    expect(response.ok()).toBeTruthy();
+    expect(response.headers()['content-type']).toContain('image/png');
+  });
+
+  test('serves timeline event image', async ({ request }) => {
+    const response = await request.get('/timeline/arab-revolt-1936-39/opengraph-image');
+    expect(response.ok()).toBeTruthy();
+    expect(response.headers()['content-type']).toContain('image/png');
+  });
+
+  test('serves place image', async ({ request }) => {
+    const response = await request.get('/places/gaza/opengraph-image');
+    expect(response.ok()).toBeTruthy();
+    expect(response.headers()['content-type']).toContain('image/png');
+  });
+});


### PR DESCRIPTION
## Summary
- add localized Open Graph image routes for chapters, timeline events, and places in English and Arabic
- point per-page metadata at the new image endpoints while keeping the global fallback for non-detail routes
- cover the new endpoints with Playwright smoke tests

## Testing
- npx playwright test tests/e2e/og-images.spec.ts

------
https://chatgpt.com/codex/tasks/task_b_6906feb91628832085f9298d4ac65604