### PR TITLE
feat(no-js): map place card anchors + noscript notice (EN + AR)

### DIFF
--- a/app/(site)/ar/map/page.tsx
+++ b/app/(site)/ar/map/page.tsx
@@ -26,6 +26,12 @@ export default function MapsPageAr({
   return (
     <main id="main" tabIndex={-1} className="mx-auto max-w-3xl px-4 py-12" dir="rtl" lang="ar">
       <h1 className="text-2xl font-semibold tracking-tight font-arabic">الأماكن</h1>
+      <noscript>
+        <p className="mt-2 rounded border bg-yellow-50 p-3 text-sm text-yellow-800 font-arabic" dir="rtl">
+          تم تعطيل JavaScript. ما زال بإمكانك تصفّح الأماكن أدناه — استخدم روابط «فتح صفحة المكان» أو «فتح على
+          الخريطة» في كل بطاقة.
+        </p>
+      </noscript>
 
       <div className="mt-4">
         <MapsPageClientAr places={places} cfg={cfg} initialFocusId={initialFocusId} />

--- a/app/map/page.tsx
+++ b/app/map/page.tsx
@@ -27,6 +27,12 @@ export default function MapsPage({
   return (
     <main id="main" tabIndex={-1} className="mx-auto max-w-3xl px-4 py-12">
       <h1 className="text-2xl font-semibold tracking-tight">Places</h1>
+      <noscript>
+        <p className="mt-2 rounded border bg-yellow-50 p-3 text-sm text-yellow-800">
+          JavaScript is disabled. You can still browse places below — use "Open place
+          page" or "Open on map" links on each card.
+        </p>
+      </noscript>
       <p className="mt-2 text-sm text-gray-600">
         Loaded from <code>data/gazetteer.json</code>
       </p>

--- a/components/MapsPageClient.ar.tsx
+++ b/components/MapsPageClient.ar.tsx
@@ -177,6 +177,24 @@ export default function MapsPageClientAr({
                   </div>
                 ) : null}
               </button>
+              <div className="mt-2 text-xs text-gray-600 flex flex-wrap gap-3">
+                <a
+                  href={`/ar/places/${p.id}`}
+                  className="underline hover:no-underline"
+                  aria-label={`فتح صفحة المكان ${displayName(p)}`}
+                  title="فتح صفحة المكان"
+                >
+                  فتح صفحة المكان →
+                </a>
+                <a
+                  href={`/ar/map?place=${encodeURIComponent(p.id)}`}
+                  className="underline hover:no-underline"
+                  aria-label={`فتح الخريطة مركّزة على ${displayName(p)}`}
+                  title="فتح الخريطة مركّزة على هذا المكان"
+                >
+                  فتح على الخريطة
+                </a>
+              </div>
             </li>
           );
         })}

--- a/components/MapsPageClient.tsx
+++ b/components/MapsPageClient.tsx
@@ -156,6 +156,24 @@ export default function MapsPageClient({
                   </div>
                 ) : null}
               </button>
+              <div className="mt-2 text-xs text-gray-600 flex flex-wrap gap-3">
+                <a
+                  href={`/places/${p.id}`}
+                  className="underline hover:no-underline"
+                  aria-label={`Open place page for ${p.name}`}
+                  title="Open place page"
+                >
+                  Open place page →
+                </a>
+                <a
+                  href={`/map?place=${encodeURIComponent(p.id)}`}
+                  className="underline hover:no-underline"
+                  aria-label={`Open map focused on ${p.name}`}
+                  title="Open map focused on this place"
+                >
+                  Open on map
+                </a>
+              </div>
             </li>
           );
         })}

--- a/tests/e2e/nojs.map-fallback.spec.ts
+++ b/tests/e2e/nojs.map-fallback.spec.ts
@@ -1,0 +1,21 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Map no-JS fallback', () => {
+  test.use({ javaScriptEnabled: false });
+
+  test('EN: can navigate via anchors and get focused view server-side', async ({ page }) => {
+    await page.goto('/map');
+    await expect(page.getByText('JavaScript is disabled.')).toBeVisible();
+    await page.getByRole('link', { name: /Open on map/i }).first().click();
+    await expect(page).toHaveURL(/\/map\?place=/);
+    await expect(page.getByText(/Focused:\s+/)).toBeVisible();
+  });
+
+  test('AR: anchors present and RTL text', async ({ page }) => {
+    await page.goto('/ar/map');
+    await expect(page.getByText('تم تعطيل JavaScript.')).toBeVisible();
+    await page.getByRole('link', { name: /فتح على الخريطة/ }).first().click();
+    await expect(page).toHaveURL(/\/ar\/map\?place=/);
+    await expect(page.getByText(/المركّز:/)).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- add progressive-enhancement links to each map place card in EN and AR clients
- surface a noscript hint on /map and /ar/map to guide non-JS visitors
- cover the no-JS flows with a dedicated Playwright e2e test

## Testing
- npx playwright test tests/e2e/nojs.map-fallback.spec.ts *(fails: Playwright browsers missing in container)*

------
https://chatgpt.com/codex/tasks/task_b_690700bd0cf88320bdcc8c66aebbac89