### PR TITLE
Fix language toggles, add place search, single-click map focus, footnotes, and a11y improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,38 @@ Next.js (App Router) · TypeScript · Tailwind · MDX · MapLibre/Leaflet · D3 
 - Ship fast, static-first pages with progressive enhancement.
 
 ## Run locally
+
 ```bash
-bun i
+# with npm
+npm install
+npm run dev
+
+# or with bun
+bun install
 bun dev
+```
+
+## Testing
+
+```bash
+npm run test:unit   # vitest
+npm run test:e2e    # playwright
+```
+
+The search index is rebuilt automatically during `npm run build` via `scripts/build-search.js`.
+
+## i18n routing
+
+Use `buildLanguageToggleHref` from `lib/i18nRoutes.ts` to derive language switcher links. The helper accepts the
+current pathname, query parameters, and the target locale, returning a safe, leading-slash URL that preserves
+existing query parameters.
+
+```ts
+import { buildLanguageToggleHref } from '@/lib/i18nRoutes';
+
+const arabicHref = buildLanguageToggleHref('/map', { place: 'haifa' }, 'ar');
+// => '/ar/map?place=haifa'
+```
 
 ## Maps
 
@@ -23,14 +52,3 @@ Routes
 
 Features
 - Marker clustering, deep links (`?place=<id>`), click any list item to focus the map, “Reset view”, “Copy link”.
-
-Run locally
-```bash
-# with npm
-npm i
-npm run dev
-
-# or with bun (already in README)
-bun i
-bun dev
-

--- a/app/(site)/ar/chapters/[slug]/page.tsx
+++ b/app/(site)/ar/chapters/[slug]/page.tsx
@@ -70,7 +70,7 @@ export default async function Page({ params }: Props) {
   const { content, frontmatter } = await compileMDX({
     source,
     components,
-    options: { parseFrontmatter: true }
+    options: { parseFrontmatter: true },
   });
 
   const meta = frontmatter as {

--- a/app/(site)/ar/chapters/[slug]/page.tsx
+++ b/app/(site)/ar/chapters/[slug]/page.tsx
@@ -8,10 +8,11 @@ import {
   loadChapterFrontmatterAr,
   hasArChapter,
 } from '@/lib/loaders.chapters';
-import { mdxComponents } from '@/mdx-components';
+import { createMdxComponents } from '@/mdx-components';
 import { loadEras } from '@/lib/loaders.timeline';
 import { loadGazetteer } from '@/lib/loaders.places';
 import JsonLd from '@/components/JsonLd';
+import { buildLanguageToggleHref } from '@/lib/i18nRoutes';
 
 export function generateStaticParams() {
   return loadChapterSlugsAr().map(slug => ({ slug }));
@@ -35,7 +36,7 @@ export function generateMetadata({ params }: { params: { slug: string } }) {
   } as const;
   return {
     title: isFallback ? `${title} (English)` : title,
-    description: summary,
+   description: summary,
     alternates: {
       canonical,
       languages,
@@ -45,6 +46,12 @@ export function generateMetadata({ params }: { params: { slug: string } }) {
       description: summary,
       images: [`/ar/chapters/${params.slug}/opengraph-image`],
       url: canonical,
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: isFallback ? `${title} (English)` : title,
+      description: summary,
+      images: [`/ar/chapters/${params.slug}/opengraph-image`],
     },
   };
 }
@@ -58,9 +65,11 @@ export default async function Page({ params }: Props) {
     notFound();
   }
   const { source, isFallback } = loadChapterSourceAr(params.slug);
+  const { components, FootnotesSection } = createMdxComponents('ar');
+
   const { content, frontmatter } = await compileMDX({
     source,
-    components: mdxComponents,
+    components,
     options: { parseFrontmatter: true }
   });
 
@@ -132,6 +141,8 @@ export default async function Page({ params }: Props) {
     mainEntityOfPage: { '@type': 'WebPage', '@id': articleUrl },
   };
 
+  const englishHref = buildLanguageToggleHref(`/ar/chapters/${params.slug}`, undefined, 'en');
+
   return (
     <>
       <JsonLd id={`ld-article-${params.slug}`} data={articleLd} />
@@ -150,7 +161,7 @@ export default async function Page({ params }: Props) {
 
         <div className="mt-2 text-sm text-gray-600">
           {enAvailable ? (
-            <a className="underline" href={`/chapters/${params.slug}`}>English</a>
+            <a className="underline" href={englishHref}>English</a>
           ) : null}
         </div>
 
@@ -184,6 +195,8 @@ export default async function Page({ params }: Props) {
         <article className="mt-8 space-y-4 font-arabic">
           {content}
         </article>
+
+        <FootnotesSection />
       </main>
     </>
   );

--- a/app/(site)/ar/chapters/[slug]/page.tsx
+++ b/app/(site)/ar/chapters/[slug]/page.tsx
@@ -36,7 +36,7 @@ export function generateMetadata({ params }: { params: { slug: string } }) {
   } as const;
   return {
     title: isFallback ? `${title} (English)` : title,
-   description: summary,
+    description: summary,
     alternates: {
       canonical,
       languages,

--- a/app/(site)/ar/layout.tsx
+++ b/app/(site)/ar/layout.tsx
@@ -5,7 +5,18 @@ import LanguageSwitcher from '@/components/LanguageSwitcher';
 
 export const metadata = {
   title: 'فلسطين',
-  description: 'تاريخ عام وفني لفلسطين'
+  description: 'تاريخ عام وفني لفلسطين',
+  openGraph: {
+    title: 'فلسطين',
+    description: 'تاريخ عام وفني لفلسطين',
+    type: 'website',
+    url: '/ar',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'فلسطين',
+    description: 'تاريخ عام وفني لفلسطين',
+  },
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {

--- a/app/(site)/ar/layout.tsx
+++ b/app/(site)/ar/layout.tsx
@@ -1,7 +1,5 @@
 import '../../globals.css';
 import type { ReactNode } from 'react';
-import { Suspense } from 'react';
-import LanguageSwitcher from '@/components/LanguageSwitcher';
 
 export const metadata = {
   title: 'فلسطين',
@@ -29,13 +27,6 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         >
           تجاوز إلى المحتوى
         </a>
-        <header className="border-b">
-          <div className="mx-auto flex max-w-4xl justify-start px-4 py-3" dir="rtl">
-            <Suspense fallback={<span className="text-sm text-gray-400">…</span>}>
-              <LanguageSwitcher />
-            </Suspense>
-          </div>
-        </header>
         <div>{children}</div>
       </body>
     </html>

--- a/app/(site)/ar/map/page.tsx
+++ b/app/(site)/ar/map/page.tsx
@@ -2,6 +2,7 @@
 import { loadGazetteer } from '@/lib/loaders.places';
 import { loadMapConfig } from '@/lib/loaders.config';
 import MapsPageClientAr from '@/components/MapsPageClient.ar';
+import { buildLanguageToggleHref } from '@/lib/i18nRoutes';
 
 export const metadata = {
   title: 'خريطة الأماكن الفلسطينية',
@@ -11,6 +12,11 @@ export const metadata = {
     languages: { en: '/map', ar: '/ar/map', 'x-default': '/map' },
   },
   openGraph: { url: '/ar/map' },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'خريطة الأماكن الفلسطينية',
+    description: 'خريطة تفاعلية مستمدة من دليل المشروع.',
+  },
 };
 
 export default function MapsPageAr({
@@ -22,7 +28,11 @@ export default function MapsPageAr({
   const cfg = loadMapConfig();
   const initialFocusId = searchParams?.place;
 
-  const enHref = initialFocusId ? `/map?place=${initialFocusId}` : '/map';
+  const enHref = buildLanguageToggleHref(
+    '/ar/map',
+    initialFocusId ? { place: initialFocusId } : undefined,
+    'en'
+  );
 
   return (
     <main id="main" tabIndex={-1} className="mx-auto max-w-3xl px-4 py-12" dir="rtl">

--- a/app/(site)/ar/page.tsx
+++ b/app/(site)/ar/page.tsx
@@ -1,4 +1,5 @@
 import SearchIsland from '@/components/SearchIsland';
+import { buildLanguageToggleHref } from '@/lib/i18nRoutes';
 
 export const metadata = {
   title: 'فلسطين',
@@ -15,9 +16,16 @@ export const metadata = {
     type: 'website',
     url: '/ar',
   },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'فلسطين',
+    description:
+      'سِجلّ عام وتاريخ رقمي فنّي يمتد على ٤٠٠٠ سنة — يركّز على الحياة الفلسطينية والذاكرة المناهضة للاستعمار.',
+  },
 } as const;
 
 export default function Page() {
+  const englishHref = buildLanguageToggleHref('/ar', undefined, 'en');
   return (
     <main id="main" tabIndex={-1} className="mx-auto max-w-3xl px-4 py-12" dir="rtl" lang="ar">
       <header className="mb-8">
@@ -59,7 +67,7 @@ export default function Page() {
       </section>
 
       <p className="mt-10 text-sm text-gray-600 font-arabic">
-        <a className="underline hover:no-underline" href="/">
+        <a className="underline hover:no-underline" href={englishHref}>
           عرض هذا الموقع بالإنجليزية →
         </a>
       </p>

--- a/app/(site)/ar/places/[id]/page.tsx
+++ b/app/(site)/ar/places/[id]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from 'next/navigation';
 import type { Metadata } from 'next';
 import JsonLd from '@/components/JsonLd';
 import { loadGazetteer } from '@/lib/loaders.places';
+import { buildLanguageToggleHref } from '@/lib/i18nRoutes';
 
 export const dynamic = 'force-static';
 
@@ -30,6 +31,12 @@ export async function generateMetadata({
       images: [`/ar/places/${p.id}/opengraph-image`],
       url: `/ar/places/${p.id}`,
     },
+    twitter: {
+      card: 'summary_large_image',
+      title: p.name,
+      description: `${p.kind ?? 'مكان'} · ${p.lat}, ${p.lon}`,
+      images: [`/ar/places/${p.id}/opengraph-image`],
+    },
   };
 }
 
@@ -37,7 +44,7 @@ export default function PlacePageAr({ params }: { params: { id: string } }) {
   const p = loadGazetteer().find((x) => x.id === params.id);
   if (!p) notFound();
 
-  const enHref = `/places/${p.id}`;
+  const enHref = buildLanguageToggleHref(`/ar/places/${p.id}`, undefined, 'en');
 
   return (
     <main id="main" tabIndex={-1} className="mx-auto max-w-3xl px-4 py-12" dir="rtl" lang="ar">

--- a/app/(site)/ar/timeline/[id]/page.tsx
+++ b/app/(site)/ar/timeline/[id]/page.tsx
@@ -43,6 +43,12 @@ export function generateMetadata({
       locale: 'ar',
       type: 'article',
     },
+    twitter: {
+      card: 'summary_large_image',
+      title: event.title,
+      description: event.summary ?? undefined,
+      images: [`/ar/timeline/${event.id}/opengraph-image`],
+    },
   };
 }
 

--- a/app/(site)/ar/timeline/page.tsx
+++ b/app/(site)/ar/timeline/page.tsx
@@ -11,6 +11,11 @@ export const metadata = {
     languages: { en: '/timeline', ar: '/ar/timeline', 'x-default': '/timeline' },
   },
   openGraph: { url: '/ar/timeline' },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'الخط الزمني',
+    description: 'خط زمني عامّ لفلسطين مع العصور والأمكنة والمصادر.',
+  },
 };
 
 export default function Page({

--- a/app/(site)/layout.tsx
+++ b/app/(site)/layout.tsx
@@ -11,7 +11,7 @@ export default function SiteSegmentLayout({ children }: { children: ReactNode })
   return (
     <div className="min-h-screen bg-white text-gray-900">
       <header className="border-b">
-        <div className="mx-auto flex max-w-4xl justify-end px-4 py-3" dir="ltr">
+        <div className="mx-auto flex max-w-4xl justify-end rtl:justify-start px-4 py-3">
           <Suspense fallback={<span className="text-sm text-gray-400">…</span>}>
             <LanguageSwitcher />
           </Suspense>

--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -1,5 +1,6 @@
 // app/(site)/page.tsx
 import SearchIsland from '@/components/SearchIsland';
+import { buildLanguageToggleHref } from '@/lib/i18nRoutes';
 
 export const metadata = {
   title: 'Palestine',
@@ -10,9 +11,16 @@ export const metadata = {
     languages: { en: '/', ar: '/ar', 'x-default': '/' },
   },
   openGraph: { url: '/' },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Palestine',
+    description:
+      'A public, art-grade digital history spanning 4,000 years — centering Palestinian life, sources, and anti-colonial memory.',
+  },
 } as const;
 
 export default function Page() {
+  const arabicHref = buildLanguageToggleHref('/', undefined, 'ar');
   return (
     <main id="main" tabIndex={-1} className="mx-auto max-w-3xl px-4 py-12">
       <header className="mb-8">
@@ -55,7 +63,7 @@ export default function Page() {
       </section>
 
       <p className="mt-10 text-sm text-gray-600">
-        <a className="underline hover:no-underline" href="/ar">
+        <a className="underline hover:no-underline" href={arabicHref}>
           View this site in Arabic →
         </a>
       </p>

--- a/app/globals.css
+++ b/app/globals.css
@@ -34,6 +34,21 @@ body {
   font-family: var(--font-inter), system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
 }
 
+a:focus-visible,
+button:focus-visible,
+[role="button"]:focus-visible {
+  outline: 2px solid #111827;
+  outline-offset: 2px;
+}
+
+.place-card a:visited {
+  color: inherit;
+}
+
+.place-card[data-selected='true'] {
+  border-color: #111827;
+}
+
 .no-js-notice {
   display: block;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -16,6 +16,12 @@ export const metadata = {
       'A bilingual, anti-colonial history of Palestine across 4,000 years — maps, timelines, sources, and chapters.',
     type: 'website',
   },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Palestine — 4,000 Years of Memory',
+    description:
+      'A bilingual, anti-colonial history of Palestine across 4,000 years — maps, timelines, sources, and chapters.',
+  },
   alternates: {
     languages: { ar: '/ar' },
   },

--- a/app/map/page.tsx
+++ b/app/map/page.tsx
@@ -83,7 +83,12 @@ export default function MapsPage({
       <MapsPageClient places={places} cfg={cfg} initialFocusId={initialFocusId} />
 
       <p className="mt-8 text-sm text-gray-600">
-        <a className="underline hover:no-underline" href={arHref}>
+        <a
+          className="underline hover:no-underline"
+          href={arHref}
+          data-testid="language-toggle-ar"
+          dir="rtl"
+        >
           View this map in Arabic →
         </a>
       </p>

--- a/app/map/page.tsx
+++ b/app/map/page.tsx
@@ -2,6 +2,7 @@
 import { loadGazetteer } from '@/lib/loaders.places';
 import { loadMapConfig } from '@/lib/loaders.config';
 import MapsPageClient from '@/components/MapsPageClient';
+import { buildLanguageToggleHref } from '@/lib/i18nRoutes';
 
 export const metadata = {
   title: 'Map of Palestinian places',
@@ -11,6 +12,11 @@ export const metadata = {
     languages: { en: '/map', ar: '/ar/map', 'x-default': '/map' },
   },
   openGraph: { url: '/map' },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Map of Palestinian places',
+    description: 'Interactive map drawn from the project gazetteer.',
+  },
 };
 
 export default function MapsPage({
@@ -22,7 +28,11 @@ export default function MapsPage({
   const cfg = loadMapConfig();
   const initialFocusId = searchParams?.place;
 
-  const arHref = initialFocusId ? `/ar/map?place=${initialFocusId}` : '/ar/map';
+  const arHref = buildLanguageToggleHref(
+    '/map',
+    initialFocusId ? { place: initialFocusId } : undefined,
+    'ar'
+  );
 
   return (
     <main id="main" tabIndex={-1} className="mx-auto max-w-3xl px-4 py-12">

--- a/app/places/[id]/page.tsx
+++ b/app/places/[id]/page.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import JsonLd from '@/components/JsonLd';
 import { loadGazetteer } from '@/lib/loaders.places';
+import { buildLanguageToggleHref } from '@/lib/i18nRoutes';
 
 export const dynamic = 'force-static';
 
@@ -32,6 +33,12 @@ export async function generateMetadata({
       images: [`/places/${p.id}/opengraph-image`],
       url: `/places/${p.id}`,
     },
+    twitter: {
+      card: 'summary_large_image',
+      title: p.name,
+      description: `${p.kind ?? 'place'} · ${p.lat}, ${p.lon}`,
+      images: [`/places/${p.id}/opengraph-image`],
+    },
   };
 }
 
@@ -39,7 +46,7 @@ export default function PlacePage({ params }: { params: { id: string } }) {
   const p = loadGazetteer().find((x) => x.id === params.id);
   if (!p) notFound();
 
-  const arHref = `/ar/places/${p.id}`;
+  const arHref = buildLanguageToggleHref(`/places/${p.id}`, undefined, 'ar');
 
   return (
     <main id="main" tabIndex={-1} className="mx-auto max-w-3xl px-4 py-12">

--- a/app/timeline/[id]/page.tsx
+++ b/app/timeline/[id]/page.tsx
@@ -42,6 +42,12 @@ export function generateMetadata({
       url: `/timeline/${event.id}`,
       type: 'article',
     },
+    twitter: {
+      card: 'summary_large_image',
+      title: event.title,
+      description: event.summary ?? undefined,
+      images: [`/timeline/${event.id}/opengraph-image`],
+    },
   };
 }
 

--- a/app/timeline/page.tsx
+++ b/app/timeline/page.tsx
@@ -11,6 +11,11 @@ export const metadata = {
     languages: { en: '/timeline', ar: '/ar/timeline', 'x-default': '/timeline' },
   },
   openGraph: { url: '/timeline' },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Timeline',
+    description: 'A public, art-grade timeline of Palestine with eras, places, and sources.',
+  },
 };
 
 export default function Page({

--- a/components/Footnotes.tsx
+++ b/components/Footnotes.tsx
@@ -1,0 +1,85 @@
+import * as React from 'react';
+
+type FootnoteEntry = {
+  index: number;
+  noteId: string;
+  refId: string;
+  content: React.ReactNode;
+  displayNumber: string;
+};
+
+type Locale = 'en' | 'ar';
+
+function numberFormatter(locale: Locale) {
+  return new Intl.NumberFormat(locale === 'ar' ? 'ar' : 'en');
+}
+
+export function createFootnotesManager(locale: Locale = 'en') {
+  let counter = 0;
+  const notes: FootnoteEntry[] = [];
+
+  const formatter = numberFormatter(locale);
+  const heading = locale === 'ar' ? 'حواشي' : 'Footnotes';
+  const backLabel = locale === 'ar' ? 'عودة إلى النص' : 'Back to text';
+  const footnoteLabel = (value: string) =>
+    locale === 'ar' ? `حاشية ${value}` : `Footnote ${value}`;
+  const backLabelWithNumber = (value: string) =>
+    locale === 'ar' ? `عودة إلى النص ${value}` : `Back to text ${value}`;
+
+  function ensureNote(entry: FootnoteEntry) {
+    const existing = notes.find((note) => note.refId === entry.refId);
+    if (!existing) {
+      notes.push(entry);
+    }
+  }
+
+  function Footnote({ children }: { children: React.ReactNode }) {
+    counter += 1;
+    const index = counter;
+    const displayNumber = formatter.format(index);
+    const noteId = `footnote-${index}`;
+    const refId = `footnote-ref-${index}`;
+
+    ensureNote({ index, noteId, refId, content: children, displayNumber });
+
+    return (
+      <sup id={refId} data-footnote-index={index}>
+        <a
+          href={`#${noteId}`}
+          className="footnote-ref underline decoration-dotted underline-offset-4 focus-visible:outline focus-visible:outline-2 focus-visible:outline-gray-900 focus-visible:outline-offset-2"
+          aria-label={footnoteLabel(displayNumber)}
+        >
+          [{displayNumber}]
+        </a>
+      </sup>
+    );
+  }
+
+  function FootnotesSection() {
+    if (notes.length === 0) return null;
+    const sorted = [...notes].sort((a, b) => a.index - b.index);
+    return (
+      <section className="mt-10" id="footnotes" aria-labelledby="footnotes-heading">
+        <h2 id="footnotes-heading" className="text-sm font-semibold text-gray-700">
+          {heading}
+        </h2>
+        <ol className="mt-2 list-decimal pl-6 text-sm text-gray-700 space-y-2">
+          {sorted.map((note) => (
+            <li key={note.noteId} id={note.noteId} className="space-y-1">
+              <div>{note.content}</div>
+              <a
+                href={`#${note.refId}`}
+                className="text-xs underline hover:no-underline"
+                aria-label={backLabelWithNumber(note.displayNumber)}
+              >
+                {backLabel}
+              </a>
+            </li>
+          ))}
+        </ol>
+      </section>
+    );
+  }
+
+  return { Footnote, FootnotesSection };
+}

--- a/components/LanguageSwitcher.tsx
+++ b/components/LanguageSwitcher.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import { usePathname, useSearchParams } from 'next/navigation';
 import { useMemo } from 'react';
+import { buildLanguageToggleHref } from '@/lib/i18nRoutes';
 
 export default function LanguageSwitcher() {
   const pathname = usePathname() ?? '/';
@@ -11,23 +12,14 @@ export default function LanguageSwitcher() {
 
   const { href, label, linkDir } = useMemo(() => {
     const isArabic = pathname === '/ar' || pathname.startsWith('/ar/');
-    const params = search ? `?${search}` : '';
+    const targetLocale = isArabic ? 'en' : 'ar';
+    const params = search ? new URLSearchParams(search) : undefined;
+    const href = buildLanguageToggleHref(pathname || '/', params, targetLocale);
 
-    if (isArabic) {
-      const withoutPrefix = pathname.replace(/^\/ar(\b|\/)/, '/');
-      const target = withoutPrefix === '' ? '/' : withoutPrefix;
-      return {
-        href: `${target}${params}` || '/',
-        label: 'English',
-        linkDir: 'ltr' as const,
-      };
-    }
-
-    const suffix = pathname === '/' ? '' : pathname;
     return {
-      href: `/ar${suffix}${params}`,
-      label: 'العربية',
-      linkDir: 'rtl' as const,
+      href,
+      label: isArabic ? 'English' : 'العربية',
+      linkDir: isArabic ? ('ltr' as const) : ('rtl' as const),
     };
   }, [pathname, search]);
 

--- a/components/LanguageSwitcher.tsx
+++ b/components/LanguageSwitcher.tsx
@@ -10,7 +10,7 @@ export default function LanguageSwitcher() {
   const searchParams = useSearchParams();
   const search = searchParams.toString();
 
-  const { href, label, linkDir } = useMemo(() => {
+  const { href, label, linkDir, testId } = useMemo(() => {
     const isArabic = pathname === '/ar' || pathname.startsWith('/ar/');
     const targetLocale = isArabic ? 'en' : 'ar';
     const params = search ? new URLSearchParams(search) : undefined;
@@ -20,6 +20,7 @@ export default function LanguageSwitcher() {
       href,
       label: isArabic ? 'English' : 'العربية',
       linkDir: isArabic ? ('ltr' as const) : ('rtl' as const),
+      testId: isArabic ? 'language-toggle-en' : 'language-toggle-ar',
     };
   }, [pathname, search]);
 
@@ -28,6 +29,7 @@ export default function LanguageSwitcher() {
       href={href}
       className="text-sm font-semibold underline decoration-dotted underline-offset-4 hover:no-underline"
       dir={linkDir}
+      data-testid={testId}
     >
       {label}
     </Link>

--- a/components/MapsPageClient.ar.tsx
+++ b/components/MapsPageClient.ar.tsx
@@ -73,6 +73,8 @@ export default function MapsPageClientAr({
     return p ? { lat: p.lat, lon: p.lon } : null;
   }, [focusId, places]);
 
+  const focusPlace = useMemo(() => places.find((x) => x.id === focusId) ?? null, [focusId, places]);
+
   const localizedPlaces = useMemo(
     () =>
       places.map((p) => ({
@@ -120,7 +122,7 @@ export default function MapsPageClientAr({
 
       <div className="mt-4 flex items-center gap-3">
         <button
-          className="rounded border px-3 py-1 text-sm hover:bg-gray-50"
+          className="rounded border px-3 py-1 text-sm hover:bg-gray-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-gray-900 focus-visible:outline-offset-2"
           onClick={() => setFitTrigger((n) => n + 1)}
           title="إعادة الضبط لعرض كل الأماكن"
           aria-label="إعادة الضبط لعرض كل الأماكن"
@@ -129,7 +131,7 @@ export default function MapsPageClientAr({
         </button>
 
         <button
-          className="rounded border px-3 py-1 text-sm hover:bg-gray-50"
+          className="rounded border px-3 py-1 text-sm hover:bg-gray-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-gray-900 focus-visible:outline-offset-2"
           onClick={copyLink}
           title="نسخ رابط قابل للمشاركة"
           aria-label="نسخ رابط قابل للمشاركة"
@@ -138,10 +140,14 @@ export default function MapsPageClientAr({
         </button>
 
         {copied ? (
-          <span className="text-xs text-green-600" aria-live="polite">تم نسخ الرابط</span>
+          <span className="text-xs text-green-600" role="status" aria-live="polite">تم نسخ الرابط</span>
         ) : null}
 
-        {focusId ? (
+        {focusPlace ? (
+          <span className="text-sm text-gray-600">
+            المركّز: <strong>{displayName(focusPlace)}</strong>
+          </span>
+        ) : focusId ? (
           <span className="text-sm text-gray-600">
             المركّز: <code className="ltr:ml-1 rtl:mr-1">{focusId}</code>
           </span>
@@ -160,11 +166,14 @@ export default function MapsPageClientAr({
           return (
             <li
               key={p.id}
-              className={`rounded border p-3 ${focused ? 'bg-yellow-50 border-yellow-300' : 'hover:bg-gray-50'}`}
+              className={`place-card rounded border p-3 transition-shadow ${
+                focused ? 'border-gray-900 bg-yellow-100 shadow-inner' : 'hover:bg-gray-50'
+              }`}
+              data-selected={focused ? 'true' : 'false'}
             >
               <button
                 type="button"
-                className="block w-full text-left"
+                className="block w-full text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-gray-900 focus-visible:outline-offset-2"
                 onClick={() => setFocusId(p.id)}
                 aria-pressed={focused}
                 aria-label={`التركيز على ${displayName(p)} في الخريطة`}
@@ -180,23 +189,24 @@ export default function MapsPageClientAr({
                   </div>
                 ) : null}
               </button>
-              <div className="mt-2 text-xs text-gray-600 flex flex-wrap gap-3">
+              <div className="mt-2 flex flex-wrap gap-3 text-xs text-gray-600">
                 <a
                   href={`/ar/places/${p.id}`}
-                  className="underline hover:no-underline"
+                  className="underline hover:no-underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-gray-900 focus-visible:outline-offset-2"
                   aria-label={`فتح صفحة المكان ${displayName(p)}`}
                   title="فتح صفحة المكان"
                 >
                   فتح صفحة المكان →
                 </a>
-                <a
-                  href={`/ar/map?place=${encodeURIComponent(p.id)}`}
-                  className="underline hover:no-underline"
+                <button
+                  type="button"
+                  className="underline hover:no-underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-gray-900 focus-visible:outline-offset-2"
+                  onClick={() => setFocusId(p.id)}
                   aria-label={`فتح الخريطة مركّزة على ${displayName(p)}`}
                   title="فتح الخريطة مركّزة على هذا المكان"
                 >
                   فتح على الخريطة
-                </a>
+                </button>
               </div>
             </li>
           );

--- a/components/MapsPageClient.tsx
+++ b/components/MapsPageClient.tsx
@@ -61,6 +61,8 @@ export default function MapsPageClient({
     return p ? { lat: p.lat, lon: p.lon } : null;
   }, [focusId, places]);
 
+  const focusPlace = useMemo(() => places.find((x) => x.id === focusId) ?? null, [focusId, places]);
+
   useEffect(() => {
     return () => {
       if (copyTimer.current) {
@@ -99,7 +101,7 @@ export default function MapsPageClient({
 
       <div className="mt-4 flex items-center gap-3">
         <button
-          className="rounded border px-3 py-1 text-sm hover:bg-gray-50"
+          className="rounded border px-3 py-1 text-sm hover:bg-gray-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-gray-900 focus-visible:outline-offset-2"
           onClick={() => setFitTrigger((n) => n + 1)}
           title="Reset view to show all places"
           aria-label="Reset view to show all places"
@@ -108,7 +110,7 @@ export default function MapsPageClient({
         </button>
 
         <button
-          className="rounded border px-3 py-1 text-sm hover:bg-gray-50"
+          className="rounded border px-3 py-1 text-sm hover:bg-gray-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-gray-900 focus-visible:outline-offset-2"
           onClick={copyLink}
           title="Copy a shareable link to this view"
           aria-label="Copy a shareable link to this view"
@@ -117,10 +119,16 @@ export default function MapsPageClient({
         </button>
 
         {copied ? (
-          <span className="text-xs text-green-600" aria-live="polite">Link copied</span>
+          <span className="text-xs text-green-600" role="status" aria-live="polite">
+            Link copied
+          </span>
         ) : null}
 
-        {focusId ? (
+        {focusPlace ? (
+          <span className="text-sm text-gray-600">
+            Focused: <strong>{focusPlace.name}</strong>
+          </span>
+        ) : focusId ? (
           <span className="text-sm text-gray-600">
             Focused: <code>{focusId}</code>
           </span>
@@ -139,11 +147,14 @@ export default function MapsPageClient({
           return (
             <li
               key={p.id}
-              className={`rounded border p-3 ${focused ? 'bg-yellow-50 border-yellow-300' : 'hover:bg-gray-50'}`}
+              className={`place-card rounded border p-3 transition-shadow ${
+                focused ? 'border-gray-900 bg-yellow-100 shadow-inner' : 'hover:bg-gray-50'
+              }`}
+              data-selected={focused ? 'true' : 'false'}
             >
               <button
                 type="button"
-                className="block w-full text-left"
+                className="block w-full text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-gray-900 focus-visible:outline-offset-2"
                 onClick={() => setFocusId(p.id)}
                 aria-pressed={focused}
                 aria-label={`Focus map on ${p.name}`}
@@ -159,23 +170,24 @@ export default function MapsPageClient({
                   </div>
                 ) : null}
               </button>
-              <div className="mt-2 text-xs text-gray-600 flex flex-wrap gap-3">
+              <div className="mt-2 flex flex-wrap gap-3 text-xs text-gray-600">
                 <a
                   href={`/places/${p.id}`}
-                  className="underline hover:no-underline"
+                  className="underline hover:no-underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-gray-900 focus-visible:outline-offset-2"
                   aria-label={`Open place page for ${p.name}`}
                   title="Open place page"
                 >
                   Open place page →
                 </a>
-                <a
-                  href={`/map?place=${encodeURIComponent(p.id)}`}
-                  className="underline hover:no-underline"
+                <button
+                  type="button"
+                  className="underline hover:no-underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-gray-900 focus-visible:outline-offset-2"
+                  onClick={() => setFocusId(p.id)}
                   aria-label={`Open map focused on ${p.name}`}
                   title="Open map focused on this place"
                 >
                   Open on map
-                </a>
+                </button>
               </div>
             </li>
           );

--- a/components/SearchClient.tsx
+++ b/components/SearchClient.tsx
@@ -28,6 +28,16 @@ export default function SearchClient({ locale = 'en' }: Props) {
         error: 'تعذّر تحميل الفهرس. حاول مجددًا.',
         empty: 'لا توجد نتائج مطابقة.',
         count: (n: number) => (n === 1 ? 'نتيجة واحدة' : `${n} من النتائج`),
+        typeLabels: {
+          chapter: 'فصل',
+          event: 'حدث',
+          place: 'مكان',
+        } as const,
+        typeIcons: {
+          chapter: '📖',
+          event: '🗓️',
+          place: '📍',
+        } as const,
       } as const;
     }
     return {
@@ -37,6 +47,16 @@ export default function SearchClient({ locale = 'en' }: Props) {
       error: 'Unable to load the search index. Please try again.',
       empty: 'No matching results yet.',
       count: (n: number) => (n === 1 ? '1 result' : `${n} results`),
+      typeLabels: {
+        chapter: 'Chapter',
+        event: 'Timeline event',
+        place: 'Place',
+      } as const,
+      typeIcons: {
+        chapter: '📖',
+        event: '🗓️',
+        place: '📍',
+      } as const,
     } as const;
   }, [isArabic]);
 
@@ -153,19 +173,40 @@ export default function SearchClient({ locale = 'en' }: Props) {
         {status !== 'error' && results.length === 0 && status !== 'loading' ? (
           <li className="rounded border p-3 text-sm text-gray-600">{t.empty}</li>
         ) : null}
-        {results.map((doc) => (
-          <li key={doc.id} className="rounded border p-3 hover:bg-gray-50">
-            <Link href={doc.href} className="block">
-              <div className="font-semibold">{doc.title}</div>
+        {results.map((doc) => {
+          const typeLabel = doc.type ? t.typeLabels[doc.type] : null;
+          const typeIcon = doc.type ? t.typeIcons[doc.type] : null;
+          return (
+            <li
+              key={doc.id}
+              className="rounded border p-3 hover:bg-gray-50 focus-within:ring-2 focus-within:ring-gray-900 focus-within:ring-offset-2 focus-within:ring-offset-white"
+            >
+              <Link
+                href={doc.href}
+                className="block focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-900 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="font-semibold">{doc.title}</div>
+                  {typeLabel ? (
+                    <span
+                      className="inline-flex items-center gap-1 rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-700"
+                      aria-label={typeLabel}
+                    >
+                      {typeIcon ? <span aria-hidden="true">{typeIcon}</span> : null}
+                      <span>{typeLabel}</span>
+                    </span>
+                  ) : null}
+                </div>
               {doc.summary ? (
                 <div className="mt-1 text-sm text-gray-600">{doc.summary}</div>
               ) : null}
               {doc.tags && doc.tags.length ? (
                 <div className="mt-1 text-xs text-gray-500">#{doc.tags.join(' #')}</div>
               ) : null}
-            </Link>
-          </li>
-        ))}
+              </Link>
+            </li>
+          );
+        })}
       </ul>
     </div>
   );

--- a/components/TimelineFilters.tsx
+++ b/components/TimelineFilters.tsx
@@ -77,7 +77,7 @@ export default function TimelineFilters({
   }
 
   const chipBaseClasses =
-    'inline-flex cursor-pointer select-none rounded-full px-3 py-1 text-sm font-medium transition-colors peer-focus-visible:outline-none peer-focus-visible:ring-2 peer-focus-visible:ring-primary-500 peer-focus-visible:ring-offset-2 peer-focus-visible:ring-offset-white dark:peer-focus-visible:ring-offset-gray-900';
+    'inline-flex cursor-pointer select-none rounded-full border px-3 py-1 text-sm font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-900 focus-visible:ring-offset-2 focus-visible:ring-offset-white';
 
   return (
     <form
@@ -103,40 +103,32 @@ export default function TimelineFilters({
         <legend className={`mb-2 text-sm font-medium text-gray-700 ${isArabic ? 'text-right' : ''}`}>
           {t.legend}
         </legend>
-        <div className={`flex flex-wrap gap-2 ${isArabic ? 'justify-end' : ''}`}>
+        <div className={`flex flex-wrap gap-2 ${isArabic ? 'justify-end' : ''}`} role="group" aria-label={t.legend}>
           {eras.map((e) => {
-            const id = `timeline-filter-${e.id}`;
             const label = isArabic ? e.title_ar ?? e.title : e.title;
             const selected = selectedEras.has(e.id);
             const stateClasses = selected
-              ? 'bg-primary-600 text-white'
-              : 'bg-gray-300 text-gray-900 hover:bg-gray-400 dark:bg-slate-700 dark:text-white dark:hover:bg-slate-600';
+              ? 'border-gray-900 bg-gray-900 text-white'
+              : 'border-gray-300 text-gray-900 hover:bg-gray-100';
             return (
-              <div key={e.id} className="flex">
-                <input
-                  type="checkbox"
-                  name="eras"
-                  value={e.id}
-                  id={id}
-                  checked={selected}
-                  onChange={() => toggleEra(e.id)}
-                  className="peer sr-only"
-                  aria-label={t.filterAria(label)}
-                />
-                <label
-                  htmlFor={id}
-                  className={`${chipBaseClasses} ${stateClasses}`}
-                  aria-pressed={selected}
-                  aria-controls="timeline-results"
-                  aria-label={t.filterAria(label)}
-                >
-                  {label}
-                </label>
-              </div>
+              <button
+                type="button"
+                key={e.id}
+                className={`${chipBaseClasses} ${stateClasses}`}
+                aria-pressed={selected}
+                aria-controls="timeline-results"
+                aria-label={t.filterAria(label)}
+                onClick={() => toggleEra(e.id)}
+                data-selected={selected ? 'true' : 'false'}
+              >
+                {label}
+              </button>
             );
           })}
         </div>
       </fieldset>
+
+      <input type="hidden" name="eras" value={Array.from(selectedEras).join(',')} />
 
       <button
         type="submit"

--- a/lib/i18nRoutes.ts
+++ b/lib/i18nRoutes.ts
@@ -1,0 +1,94 @@
+export type Locale = 'en' | 'ar';
+
+type QueryInput =
+  | string
+  | URLSearchParams
+  | Record<string, string | number | boolean | string[] | undefined>
+  | Array<[string, string]>;
+
+function normalisePath(pathname: string): string {
+  if (!pathname || pathname === '/') {
+    return '/';
+  }
+  const trimmed = pathname.trim();
+  if (trimmed === '') return '/';
+  const withSlash = trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+  const normalised = withSlash.replace(/\/+/g, '/');
+  return normalised === '' ? '/' : normalised;
+}
+
+function stripArabicPrefix(pathname: string): string {
+  const normalised = normalisePath(pathname);
+  if (normalised === '/ar') {
+    return '/';
+  }
+  if (normalised.startsWith('/ar/')) {
+    const rest = normalised.slice(3);
+    return rest.startsWith('/') ? rest : `/${rest}`;
+  }
+  return normalised;
+}
+
+function buildSearch(query?: QueryInput): string {
+  if (!query) return '';
+  if (typeof query === 'string') {
+    const trimmed = query.trim().replace(/^\?/, '');
+    return trimmed ? `?${trimmed}` : '';
+  }
+  const params = new URLSearchParams();
+  if (query instanceof URLSearchParams) {
+    query.forEach((value, key) => {
+      if (value !== undefined && value !== null) {
+        params.append(key, value);
+      }
+    });
+  } else if (Array.isArray(query)) {
+    for (const [key, value] of query) {
+      if (value !== undefined && value !== null) {
+        params.append(key, value);
+      }
+    }
+  } else {
+    for (const [key, value] of Object.entries(query)) {
+      if (value === undefined || value === null) continue;
+      if (Array.isArray(value)) {
+        value.forEach((v) => {
+          if (v !== undefined && v !== null) {
+            params.append(key, String(v));
+          }
+        });
+      } else if (typeof value === 'boolean') {
+        params.append(key, value ? 'true' : 'false');
+      } else {
+        params.append(key, String(value));
+      }
+    }
+  }
+  const serialised = params.toString();
+  return serialised ? `?${serialised}` : '';
+}
+
+export function buildLanguageToggleHref(
+  pathname: string,
+  query: QueryInput | undefined,
+  targetLocale: Locale
+): string {
+  const withoutAr = stripArabicPrefix(pathname);
+  const search = buildSearch(query);
+
+  if (targetLocale === 'ar') {
+    const suffix = withoutAr === '/' ? '' : withoutAr;
+    return `/ar${suffix}${search}` || '/ar';
+  }
+
+  const base = withoutAr || '/';
+  return `${base}${search}` || '/';
+}
+
+export function deriveAlternateHref(
+  currentPath: string,
+  query: QueryInput | undefined,
+  targetLocale: Locale
+): string {
+  return buildLanguageToggleHref(currentPath, query, targetLocale);
+}

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { citeById, shortCiteById } from '@/lib/bibliography';
+import { createFootnotesManager } from '@/components/Footnotes';
 
 function Cite({ id, children }: { id?: string; children?: React.ReactNode }) {
-  const short = id ? shortCiteById(id) : (children ? String(children) : '');
+  const short = id ? shortCiteById(id) : children ? String(children) : '';
   const full = id ? citeById(id) : short;
   const hasPlaceholder = /TODO/i.test(full) || /\[missing:/.test(full) || /Stub entry/i.test(full);
   return (
@@ -17,21 +18,13 @@ function Cite({ id, children }: { id?: string; children?: React.ReactNode }) {
   );
 }
 
-function Footnote({ children }: { children: React.ReactNode }) {
-  const text = typeof children === 'string' ? children : undefined;
-  return (
-    <sup
-      style={{ fontSize: '0.75em', lineHeight: 1 }}
-      className="align-super"
-      aria-label="footnote"
-      title={text}
-    >
-      †
-    </sup>
-  );
+export function createMdxComponents(locale: 'en' | 'ar' = 'en') {
+  const { Footnote, FootnotesSection } = createFootnotesManager(locale);
+  return {
+    components: {
+      Cite,
+      Footnote,
+    },
+    FootnotesSection,
+  } as const;
 }
-
-export const mdxComponents = {
-  Cite,
-  Footnote,
-};

--- a/public/search.ar.json
+++ b/public/search.ar.json
@@ -135,7 +135,6 @@
     "summary": "مدينة · 31.502, 34.467",
     "tags": [
       "Ghazzah",
-      "غزة",
       "غزة"
     ],
     "href": "/ar/places/gaza",
@@ -149,7 +148,6 @@
     "tags": [
       "Yafo",
       "Yafa",
-      "يافا",
       "يافا"
     ],
     "href": "/ar/places/jaffa",
@@ -162,7 +160,6 @@
     "summary": "مدينة · 31.533, 35.100",
     "tags": [
       "Al-Khalil",
-      "الخليل",
       "الخليل"
     ],
     "href": "/ar/places/hebron",
@@ -175,7 +172,6 @@
     "summary": "مدينة · 31.870, 35.443",
     "tags": [
       "Ariha",
-      "أريحا",
       "أريحا"
     ],
     "href": "/ar/places/jericho",
@@ -189,7 +185,6 @@
     "tags": [
       "Nablus",
       "שכם",
-      "نابلس",
       "نابلس"
     ],
     "href": "/ar/places/shechem",
@@ -202,7 +197,6 @@
     "summary": "مدينة · 31.904, 35.203",
     "tags": [
       "Rām Allāh",
-      "رام الله",
       "رام الله"
     ],
     "href": "/ar/places/ramallah",
@@ -215,8 +209,7 @@
     "summary": "مدينة ساحلية · 32.816, 34.990",
     "tags": [
       "حيفا",
-      "Ḥayfa",
-      "حيفا"
+      "Ḥayfa"
     ],
     "href": "/ar/places/haifa",
     "lang": "ar",
@@ -229,7 +222,6 @@
     "tags": [
       "Lod",
       "לוד",
-      "اللد",
       "اللد"
     ],
     "href": "/ar/places/lydda",
@@ -241,7 +233,6 @@
     "title": "الرملة",
     "summary": "مدينة · 31.931, 34.873",
     "tags": [
-      "الرملة",
       "الرملة"
     ],
     "href": "/ar/places/ramla",
@@ -255,7 +246,6 @@
     "tags": [
       "ʿAkka",
       "Akka",
-      "عكا",
       "عكا"
     ],
     "href": "/ar/places/acre",
@@ -270,7 +260,6 @@
       "Safed",
       "Ṣafad",
       "צפת",
-      "صفد",
       "صفد"
     ],
     "href": "/ar/places/safad",

--- a/public/search.ar.json
+++ b/public/search.ar.json
@@ -128,5 +128,153 @@
     "href": "/ar/timeline#icj-wall-2004",
     "lang": "ar",
     "type": "event"
+  },
+  {
+    "id": "/ar/places/gaza",
+    "title": "غزة",
+    "summary": "مدينة · 31.502, 34.467",
+    "tags": [
+      "Ghazzah",
+      "غزة",
+      "غزة"
+    ],
+    "href": "/ar/places/gaza",
+    "lang": "ar",
+    "type": "place"
+  },
+  {
+    "id": "/ar/places/jaffa",
+    "title": "يافا",
+    "summary": "مدينة ساحلية · 32.050, 34.752",
+    "tags": [
+      "Yafo",
+      "Yafa",
+      "يافا",
+      "يافا"
+    ],
+    "href": "/ar/places/jaffa",
+    "lang": "ar",
+    "type": "place"
+  },
+  {
+    "id": "/ar/places/hebron",
+    "title": "الخليل",
+    "summary": "مدينة · 31.533, 35.100",
+    "tags": [
+      "Al-Khalil",
+      "الخليل",
+      "الخليل"
+    ],
+    "href": "/ar/places/hebron",
+    "lang": "ar",
+    "type": "place"
+  },
+  {
+    "id": "/ar/places/jericho",
+    "title": "أريحا",
+    "summary": "مدينة · 31.870, 35.443",
+    "tags": [
+      "Ariha",
+      "أريحا",
+      "أريحا"
+    ],
+    "href": "/ar/places/jericho",
+    "lang": "ar",
+    "type": "place"
+  },
+  {
+    "id": "/ar/places/shechem",
+    "title": "نابلس",
+    "summary": "مدينة · 32.221, 35.254",
+    "tags": [
+      "Nablus",
+      "שכם",
+      "نابلس",
+      "نابلس"
+    ],
+    "href": "/ar/places/shechem",
+    "lang": "ar",
+    "type": "place"
+  },
+  {
+    "id": "/ar/places/ramallah",
+    "title": "رام الله",
+    "summary": "مدينة · 31.904, 35.203",
+    "tags": [
+      "Rām Allāh",
+      "رام الله",
+      "رام الله"
+    ],
+    "href": "/ar/places/ramallah",
+    "lang": "ar",
+    "type": "place"
+  },
+  {
+    "id": "/ar/places/haifa",
+    "title": "حيفا",
+    "summary": "مدينة ساحلية · 32.816, 34.990",
+    "tags": [
+      "حيفا",
+      "Ḥayfa",
+      "حيفا"
+    ],
+    "href": "/ar/places/haifa",
+    "lang": "ar",
+    "type": "place"
+  },
+  {
+    "id": "/ar/places/lydda",
+    "title": "اللد",
+    "summary": "مدينة · 31.952, 34.889",
+    "tags": [
+      "Lod",
+      "לוד",
+      "اللد",
+      "اللد"
+    ],
+    "href": "/ar/places/lydda",
+    "lang": "ar",
+    "type": "place"
+  },
+  {
+    "id": "/ar/places/ramla",
+    "title": "الرملة",
+    "summary": "مدينة · 31.931, 34.873",
+    "tags": [
+      "الرملة",
+      "الرملة"
+    ],
+    "href": "/ar/places/ramla",
+    "lang": "ar",
+    "type": "place"
+  },
+  {
+    "id": "/ar/places/acre",
+    "title": "عكا",
+    "summary": "مدينة ساحلية · 32.924, 35.082",
+    "tags": [
+      "ʿAkka",
+      "Akka",
+      "عكا",
+      "عكا"
+    ],
+    "href": "/ar/places/acre",
+    "lang": "ar",
+    "type": "place"
+  },
+  {
+    "id": "/ar/places/safad",
+    "title": "صفد",
+    "summary": "مدينة · 32.965, 35.496",
+    "tags": [
+      "Safed",
+      "Ṣafad",
+      "צפת",
+      "صفد",
+      "صفد"
+    ],
+    "href": "/ar/places/safad",
+    "lang": "ar",
+    "type": "place"
   }
 ]

--- a/public/search.en.json
+++ b/public/search.en.json
@@ -198,5 +198,153 @@
     "href": "/timeline#gaza-genocide-2023-present",
     "lang": "en",
     "type": "event"
+  },
+  {
+    "id": "/places/gaza",
+    "title": "Gaza",
+    "summary": "city · 31.502, 34.467",
+    "tags": [
+      "Ghazzah",
+      "غزة",
+      "غزة"
+    ],
+    "href": "/places/gaza",
+    "lang": "en",
+    "type": "place"
+  },
+  {
+    "id": "/places/jaffa",
+    "title": "Jaffa",
+    "summary": "port city · 32.050, 34.752",
+    "tags": [
+      "Yafo",
+      "Yafa",
+      "يافا",
+      "يافا"
+    ],
+    "href": "/places/jaffa",
+    "lang": "en",
+    "type": "place"
+  },
+  {
+    "id": "/places/hebron",
+    "title": "Hebron",
+    "summary": "city · 31.533, 35.100",
+    "tags": [
+      "Al-Khalil",
+      "الخليل",
+      "الخليل"
+    ],
+    "href": "/places/hebron",
+    "lang": "en",
+    "type": "place"
+  },
+  {
+    "id": "/places/jericho",
+    "title": "Jericho",
+    "summary": "city · 31.870, 35.443",
+    "tags": [
+      "Ariha",
+      "أريحا",
+      "أريحا"
+    ],
+    "href": "/places/jericho",
+    "lang": "en",
+    "type": "place"
+  },
+  {
+    "id": "/places/shechem",
+    "title": "Shechem",
+    "summary": "city · 32.221, 35.254",
+    "tags": [
+      "Nablus",
+      "שכם",
+      "نابلس",
+      "نابلس"
+    ],
+    "href": "/places/shechem",
+    "lang": "en",
+    "type": "place"
+  },
+  {
+    "id": "/places/ramallah",
+    "title": "Ramallah",
+    "summary": "city · 31.904, 35.203",
+    "tags": [
+      "Rām Allāh",
+      "رام الله",
+      "رام الله"
+    ],
+    "href": "/places/ramallah",
+    "lang": "en",
+    "type": "place"
+  },
+  {
+    "id": "/places/haifa",
+    "title": "Haifa",
+    "summary": "port city · 32.816, 34.990",
+    "tags": [
+      "حيفا",
+      "Ḥayfa",
+      "حيفا"
+    ],
+    "href": "/places/haifa",
+    "lang": "en",
+    "type": "place"
+  },
+  {
+    "id": "/places/lydda",
+    "title": "Lydda",
+    "summary": "city · 31.952, 34.889",
+    "tags": [
+      "Lod",
+      "לוד",
+      "اللد",
+      "اللد"
+    ],
+    "href": "/places/lydda",
+    "lang": "en",
+    "type": "place"
+  },
+  {
+    "id": "/places/ramla",
+    "title": "Ramla",
+    "summary": "city · 31.931, 34.873",
+    "tags": [
+      "الرملة",
+      "الرملة"
+    ],
+    "href": "/places/ramla",
+    "lang": "en",
+    "type": "place"
+  },
+  {
+    "id": "/places/acre",
+    "title": "Acre",
+    "summary": "port city · 32.924, 35.082",
+    "tags": [
+      "ʿAkka",
+      "Akka",
+      "عكا",
+      "عكا"
+    ],
+    "href": "/places/acre",
+    "lang": "en",
+    "type": "place"
+  },
+  {
+    "id": "/places/safad",
+    "title": "Safad",
+    "summary": "city · 32.965, 35.496",
+    "tags": [
+      "Safed",
+      "Ṣafad",
+      "צפת",
+      "صفد",
+      "صفد"
+    ],
+    "href": "/places/safad",
+    "lang": "en",
+    "type": "place"
   }
 ]

--- a/public/search.en.json
+++ b/public/search.en.json
@@ -205,7 +205,6 @@
     "summary": "city · 31.502, 34.467",
     "tags": [
       "Ghazzah",
-      "غزة",
       "غزة"
     ],
     "href": "/places/gaza",
@@ -219,7 +218,6 @@
     "tags": [
       "Yafo",
       "Yafa",
-      "يافا",
       "يافا"
     ],
     "href": "/places/jaffa",
@@ -232,7 +230,6 @@
     "summary": "city · 31.533, 35.100",
     "tags": [
       "Al-Khalil",
-      "الخليل",
       "الخليل"
     ],
     "href": "/places/hebron",
@@ -245,7 +242,6 @@
     "summary": "city · 31.870, 35.443",
     "tags": [
       "Ariha",
-      "أريحا",
       "أريحا"
     ],
     "href": "/places/jericho",
@@ -259,7 +255,6 @@
     "tags": [
       "Nablus",
       "שכם",
-      "نابلس",
       "نابلس"
     ],
     "href": "/places/shechem",
@@ -272,7 +267,6 @@
     "summary": "city · 31.904, 35.203",
     "tags": [
       "Rām Allāh",
-      "رام الله",
       "رام الله"
     ],
     "href": "/places/ramallah",
@@ -285,8 +279,7 @@
     "summary": "port city · 32.816, 34.990",
     "tags": [
       "حيفا",
-      "Ḥayfa",
-      "حيفا"
+      "Ḥayfa"
     ],
     "href": "/places/haifa",
     "lang": "en",
@@ -299,7 +292,6 @@
     "tags": [
       "Lod",
       "לוד",
-      "اللد",
       "اللد"
     ],
     "href": "/places/lydda",
@@ -311,7 +303,6 @@
     "title": "Ramla",
     "summary": "city · 31.931, 34.873",
     "tags": [
-      "الرملة",
       "الرملة"
     ],
     "href": "/places/ramla",
@@ -325,7 +316,6 @@
     "tags": [
       "ʿAkka",
       "Akka",
-      "عكا",
       "عكا"
     ],
     "href": "/places/acre",
@@ -340,7 +330,6 @@
       "Safed",
       "Ṣafad",
       "צפת",
-      "صفد",
       "صفد"
     ],
     "href": "/places/safad",

--- a/scripts/build-search.d.mts
+++ b/scripts/build-search.d.mts
@@ -1,0 +1,13 @@
+export type SearchDoc = {
+  id: string;
+  title: string;
+  summary: string;
+  tags: string[];
+  href: string;
+  lang: 'en' | 'ar';
+  type: 'chapter' | 'event' | 'place';
+};
+
+export declare function loadChapterDocs(): Promise<SearchDoc[]>;
+export declare function loadTimelineDocs(): Promise<SearchDoc[]>;
+export declare function loadPlaceDocs(): Promise<SearchDoc[]>;

--- a/tests/e2e/a11y.map-list-buttons.spec.ts
+++ b/tests/e2e/a11y.map-list-buttons.spec.ts
@@ -5,12 +5,12 @@ test('english map place buttons support keyboard activation', async ({ page }) =
 
   const gazaButton = page.getByRole('button', { name: 'Focus map on Gaza' });
   await gazaButton.press('Enter');
-  await expect(page.getByText('Focused: gaza')).toBeVisible();
+  await expect(page.getByText('Focused: Gaza')).toBeVisible();
   await expect(gazaButton).toHaveAttribute('aria-pressed', 'true');
 
   const jaffaButton = page.getByRole('button', { name: 'Focus map on Jaffa' });
   await jaffaButton.press(' ');
-  await expect(page.getByText('Focused: jaffa')).toBeVisible();
+  await expect(page.getByText('Focused: Jaffa')).toBeVisible();
   await expect(jaffaButton).toHaveAttribute('aria-pressed', 'true');
   await expect(gazaButton).toHaveAttribute('aria-pressed', 'false');
 });
@@ -20,12 +20,12 @@ test('arabic map place buttons expose pressed state for keyboard users', async (
 
   const gazaButton = page.getByRole('button', { name: 'التركيز على غزة في الخريطة' });
   await gazaButton.press('Enter');
-  await expect(page.getByText('المركّز: gaza')).toBeVisible();
+  await expect(page.getByText('المركّز: غزة')).toBeVisible();
   await expect(gazaButton).toHaveAttribute('aria-pressed', 'true');
 
   const jaffaButton = page.getByRole('button', { name: 'التركيز على يافا في الخريطة' });
   await jaffaButton.press(' ');
-  await expect(page.getByText('المركّز: jaffa')).toBeVisible();
+  await expect(page.getByText('المركّز: يافا')).toBeVisible();
   await expect(jaffaButton).toHaveAttribute('aria-pressed', 'true');
   await expect(gazaButton).toHaveAttribute('aria-pressed', 'false');
 });

--- a/tests/e2e/a11y.timeline-filters.spec.ts
+++ b/tests/e2e/a11y.timeline-filters.spec.ts
@@ -10,36 +10,31 @@ test('timeline filters expose accessible names and focus styles', async ({ page 
   const resultsRegion = page.locator('#timeline-results');
   await resultsRegion.waitFor({ state: 'visible' });
 
-  const foundationsCheckbox = page.locator('input#timeline-filter-foundations');
-  await foundationsCheckbox.waitFor({ state: 'attached' });
+  const foundationsButton = page.getByRole('button', { name: 'Filter by era Foundations' });
+  await foundationsButton.waitFor({ state: 'visible' });
+  await expect(foundationsButton).toHaveAttribute('aria-controls', 'timeline-results');
+  await expect(foundationsButton).toHaveAttribute('aria-label', 'Filter by era Foundations');
 
-  const foundationsLabel = page.locator('label[for="timeline-filter-foundations"]');
-  await foundationsLabel.waitFor({ state: 'visible' });
-  await expect(foundationsLabel).toHaveAttribute('aria-controls', 'timeline-results');
-  await expect(foundationsLabel).toHaveAttribute('aria-label', 'Filter by era Foundations');
+  await foundationsButton.focus();
+  await expect(foundationsButton).toBeFocused();
 
-  await foundationsCheckbox.focus();
-  await expect(foundationsCheckbox).toBeFocused();
-
-  const focusShadow = await foundationsLabel.evaluate((el) => getComputedStyle(el).boxShadow);
-  expect(focusShadow).not.toBe('none');
-  expect(focusShadow).not.toBe('rgba(0, 0, 0, 0) 0px 0px 0px 0px');
+  const outlineWidth = await foundationsButton.evaluate((el) => getComputedStyle(el).outlineWidth);
+  expect(outlineWidth).not.toBe('0px');
 
   const earlyEvent = page.getByRole('heading', { level: 3, name: foundationsHeading });
   await expect(earlyEvent).toBeVisible();
 
-  const modernLabel = page.locator('label[for="timeline-filter-modern"]');
-  await modernLabel.waitFor({ state: 'visible' });
-  await expect(modernLabel).toHaveAttribute('aria-label', 'Filter by era Modern / Nakba → Present');
+  const modernButton = page.getByRole('button', { name: 'Filter by era Modern / Nakba → Present' });
+  await modernButton.waitFor({ state: 'visible' });
 
-  await modernLabel.click();
-  await expect(modernLabel).toHaveAttribute('aria-pressed', 'true');
+  await modernButton.click();
+  await expect(modernButton).toHaveAttribute('aria-pressed', 'true');
   await expect(page.getByRole('heading', { level: 3, name: revoltHeading })).toBeVisible();
   await expect(earlyEvent).not.toBeVisible();
 
   await expect(resultsRegion).toHaveAttribute('aria-live', 'polite');
 
-  await foundationsLabel.click();
-  await expect(foundationsLabel).toHaveAttribute('aria-pressed', 'true');
+  await foundationsButton.click();
+  await expect(foundationsButton).toHaveAttribute('aria-pressed', 'true');
   await expect(earlyEvent).toBeVisible();
 });

--- a/tests/e2e/footnotes.spec.ts
+++ b/tests/e2e/footnotes.spec.ts
@@ -1,0 +1,12 @@
+import { expect, test } from '@playwright/test';
+
+test('chapter footnotes link to sources section and return to text', async ({ page }) => {
+  await page.goto('/chapters/001-prologue');
+  const footnoteLink = page.getByRole('link', { name: 'Footnote 1' });
+  await footnoteLink.click();
+  await expect(page).toHaveURL(/#footnote-1$/);
+  const footnotesSection = page.locator('#footnotes');
+  await expect(footnotesSection).toBeVisible();
+  await page.getByRole('link', { name: 'Back to text' }).click();
+  await expect(page).toHaveURL(/#footnote-ref-1$/);
+});

--- a/tests/e2e/home.search.spec.ts
+++ b/tests/e2e/home.search.spec.ts
@@ -28,3 +28,12 @@ test('search index loads without MiniSearch id errors', async ({ page }) => {
 
   expect(miniSearchErrors).toHaveLength(0);
 });
+
+test('home search surfaces places with direct navigation', async ({ page }) => {
+  await page.goto('/');
+  await page.getByLabel('Search').fill('Haifa');
+  const placeLink = page.getByRole('link', { name: /Haifa/ }).first();
+  await expect(placeLink).toBeVisible();
+  await placeLink.click();
+  await expect(page).toHaveURL('/places/haifa');
+});

--- a/tests/e2e/i18n.toggle.spec.ts
+++ b/tests/e2e/i18n.toggle.spec.ts
@@ -8,21 +8,21 @@ test('Arabic home links back to English', async ({ page }) => {
 
 test('Arabic map preserves place query when switching to English', async ({ page }) => {
   await page.goto('/ar/map?place=ramla');
-  await page.getByRole('link', { name: 'English' }).click();
+  await page.getByTestId('language-toggle-en').click();
   await expect(page).toHaveURL(/\/map\?place=ramla$/);
   await expect(page.getByText('Focused: Ramla')).toBeVisible();
 });
 
 test('English map keeps focus when switching to Arabic', async ({ page }) => {
   await page.goto('/map?place=haifa');
-  await page.getByRole('link', { name: 'العربية' }).click();
+  await page.getByTestId('language-toggle-ar').click();
   await expect(page).toHaveURL(/\/ar\/map\?place=haifa$/);
   await expect(page.getByText('المركّز: حيفا')).toBeVisible();
 });
 
 test('Timeline queries persist across language toggle', async ({ page }) => {
   await page.goto('/ar/timeline?q=ICJ&eras=modern');
-  await page.getByRole('link', { name: 'English' }).click();
+  await page.getByTestId('language-toggle-en').click();
   await expect(page).toHaveURL(/\/timeline\?q=ICJ&eras=modern$/);
   await expect(page.getByRole('heading', { level: 1, name: 'Timeline' })).toBeVisible();
 });

--- a/tests/e2e/i18n.toggle.spec.ts
+++ b/tests/e2e/i18n.toggle.spec.ts
@@ -5,3 +5,30 @@ test('Arabic home links back to English', async ({ page }) => {
   await page.getByRole('link', { name: 'عرض هذا الموقع بالإنجليزية →' }).click();
   await expect(page.getByRole('heading', { level: 1, name: 'Palestine' })).toBeVisible();
 });
+
+test('Arabic map preserves place query when switching to English', async ({ page }) => {
+  await page.goto('/ar/map?place=ramla');
+  await page.getByRole('link', { name: 'English' }).click();
+  await expect(page).toHaveURL(/\/map\?place=ramla$/);
+  await expect(page.getByText('Focused: Ramla')).toBeVisible();
+});
+
+test('English map keeps focus when switching to Arabic', async ({ page }) => {
+  await page.goto('/map?place=haifa');
+  await page.getByRole('link', { name: 'العربية' }).click();
+  await expect(page).toHaveURL(/\/ar\/map\?place=haifa$/);
+  await expect(page.getByText('المركّز: حيفا')).toBeVisible();
+});
+
+test('Timeline queries persist across language toggle', async ({ page }) => {
+  await page.goto('/ar/timeline?q=ICJ&eras=modern');
+  await page.getByRole('link', { name: 'English' }).click();
+  await expect(page).toHaveURL(/\/timeline\?q=ICJ&eras=modern$/);
+  await expect(page.getByRole('heading', { level: 1, name: 'Timeline' })).toBeVisible();
+});
+
+test('Chapter language link routes to Arabic version', async ({ page }) => {
+  await page.goto('/chapters/001-prologue');
+  await page.getByRole('link', { name: 'View this chapter in Arabic →' }).click();
+  await expect(page).toHaveURL('/ar/chapters/001-prologue');
+});

--- a/tests/e2e/map.focus.spec.ts
+++ b/tests/e2e/map.focus.spec.ts
@@ -12,8 +12,16 @@ test('map focuses on requested place and copies link', async ({ page }) => {
   });
 
   await page.goto(canonicalMapUrl);
-  await expect(page.getByText('Focused: gaza')).toBeVisible();
+  await expect(page.getByText('Focused: Gaza')).toBeVisible();
 
   await page.getByRole('button', { name: 'Copy a shareable link to this view' }).click();
   await expect(page.getByText('Link copied')).toBeVisible();
+});
+
+test('open on map button focuses immediately', async ({ page }) => {
+  await page.goto('/map');
+  const jaffaButton = page.getByRole('button', { name: 'Open map focused on Jaffa' });
+  await jaffaButton.click();
+  await expect(page).toHaveURL(/\/map\?place=jaffa/);
+  await expect(page.getByText('Focused: Jaffa')).toBeVisible();
 });

--- a/tests/e2e/timeline.filters.spec.ts
+++ b/tests/e2e/timeline.filters.spec.ts
@@ -4,14 +4,14 @@ test('timeline filters by era checkboxes', async ({ page }) => {
   await page.goto('/timeline');
   await page.waitForLoadState('networkidle');
 
-  const modernLabel = page.locator('label[for="timeline-filter-modern"]');
-  await modernLabel.waitFor({ state: 'visible' });
+  const modernButton = page.getByRole('button', { name: 'Filter by era Modern / Nakba → Present' });
+  await modernButton.waitFor({ state: 'visible' });
 
   const foundationsHeading = page.getByRole('heading', { level: 3, name: 'Canaanite urban networks flourish' });
   await expect(foundationsHeading).toBeVisible();
 
-  await modernLabel.click();
-  await expect(modernLabel).toHaveAttribute('aria-pressed', 'true');
+  await modernButton.click();
+  await expect(modernButton).toHaveAttribute('aria-pressed', 'true');
 
   await expect(foundationsHeading).not.toBeVisible();
   await expect(page.getByRole('heading', { level: 3, name: 'The 1936–39 Arab Revolt' })).toBeVisible();

--- a/tests/unit/i18nRoutes.test.ts
+++ b/tests/unit/i18nRoutes.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { buildLanguageToggleHref } from '@/lib/i18nRoutes';
+
+describe('buildLanguageToggleHref', () => {
+  it('removes arabic prefix when targeting english', () => {
+    expect(buildLanguageToggleHref('/ar/map', undefined, 'en')).toBe('/map');
+    expect(buildLanguageToggleHref('/ar', undefined, 'en')).toBe('/');
+  });
+
+  it('adds arabic prefix when targeting arabic', () => {
+    expect(buildLanguageToggleHref('/map', undefined, 'ar')).toBe('/ar/map');
+    expect(buildLanguageToggleHref('/', undefined, 'ar')).toBe('/ar');
+  });
+
+  it('preserves query parameters regardless of order', () => {
+    const query = new URLSearchParams({ place: 'haifa', era: 'modern' });
+    expect(buildLanguageToggleHref('/map', query, 'ar')).toBe('/ar/map?place=haifa&era=modern');
+    expect(buildLanguageToggleHref('/ar/map', query, 'en')).toBe('/map?place=haifa&era=modern');
+  });
+
+  it('handles plain query strings', () => {
+    expect(buildLanguageToggleHref('/timeline', '?q=ICJ&eras=modern', 'ar')).toBe('/ar/timeline?q=ICJ&eras=modern');
+  });
+
+  it('handles array-based query input', () => {
+    const tupleQuery: Array<[string, string]> = [
+      ['place', 'ramla'],
+      ['eras', 'modern'],
+    ];
+    expect(buildLanguageToggleHref('/map', tupleQuery, 'ar')).toBe('/ar/map?place=ramla&eras=modern');
+  });
+
+  it('ignores undefined values in object queries', () => {
+    expect(
+      buildLanguageToggleHref('/timeline', { q: 'ICJ', eras: undefined, include: ['modern', 'nakba'] }, 'en')
+    ).toBe('/timeline?q=ICJ&include=modern&include=nakba');
+  });
+});

--- a/tests/unit/search-places.test.ts
+++ b/tests/unit/search-places.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { loadPlaceDocs } from '../../scripts/build-search.js';
+const loadPlaceDocs = async () => {
+  const mod = await import('../../scripts/build-search.js');
+  const fn = (mod as Record<string, unknown>).loadPlaceDocs;
+  if (typeof fn !== 'function') {
+    throw new Error('loadPlaceDocs export is missing from build-search.js');
+  }
+  return fn();
+};
 
 function findDoc(docs: Array<Record<string, unknown>>, href: string) {
   return docs.find((doc) => doc && typeof doc === 'object' && doc.href === href);

--- a/tests/unit/search-places.test.ts
+++ b/tests/unit/search-places.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { loadPlaceDocs } from '../../scripts/build-search.js';
+
+function findDoc(docs: Array<Record<string, unknown>>, href: string) {
+  return docs.find((doc) => doc && typeof doc === 'object' && doc.href === href);
+}
+
+describe('search place indexing', () => {
+  it('includes places with alternate names in the search index', async () => {
+    const docs = await loadPlaceDocs();
+    const haifa = findDoc(docs, '/places/haifa');
+    expect(haifa).toBeTruthy();
+    expect(haifa?.type).toBe('place');
+    expect(Array.isArray(haifa?.tags)).toBe(true);
+    expect((haifa?.tags as string[]).includes('حيفا')).toBe(true);
+  });
+
+  it('includes arabic variants when available', async () => {
+    const docs = await loadPlaceDocs();
+    const haifaAr = findDoc(docs, '/ar/places/haifa');
+    expect(haifaAr).toBeTruthy();
+    expect(haifaAr?.lang).toBe('ar');
+  });
+});

--- a/tests/unit/search-places.test.ts
+++ b/tests/unit/search-places.test.ts
@@ -21,4 +21,12 @@ describe('search place indexing', () => {
     expect(haifaAr).toBeTruthy();
     expect(haifaAr?.lang).toBe('ar');
   });
+
+  it('deduplicates place tags across locales', async () => {
+    const docs = await loadPlaceDocs();
+    const haifaAr = findDoc(docs, '/ar/places/haifa');
+    expect(haifaAr).toBeTruthy();
+    const tags = Array.isArray(haifaAr?.tags) ? (haifaAr?.tags as string[]) : [];
+    expect(new Set(tags).size).toBe(tags.length);
+  });
 });


### PR DESCRIPTION
## Summary
- add a shared URL helper and update language toggles to preserve context across locales
- extend the search index/UI to include place records and label result types
- make map place controls single-click, add accessible footnotes, and refresh focus/metadata styles
- add unit and e2e tests covering the new helpers and interactions

## Testing
- npm run test:unit
- npm run build
- npm run test:e2e *(fails: Playwright browsers could not be downloaded in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_b_69072e61e6e0832e88d2ba06d54dbb6a