### PR TITLE
feat(cms): private Git-based CMS with protected admin UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,21 @@
+# Basic authentication for /admin and /api/cms
+BASIC_AUTH_USER=
+BASIC_AUTH_PASS=
+
+# CMS backend mode
+CMS_MODE=token
+
+# GitHub token mode
+CMS_GITHUB_TOKEN=
+
+# GitHub OAuth mode
+GITHUB_CLIENT_ID=
+GITHUB_CLIENT_SECRET=
+CMS_ALLOWED_USERS=joshua@example.org
+
+# Optional overrides
+CMS_GITHUB_REPO=
+CMS_GITHUB_BRANCH=
+
+# External services
+LIBRETRANSLATE_URL=

--- a/.github/workflows/update-search.yml
+++ b/.github/workflows/update-search.yml
@@ -1,0 +1,30 @@
+name: Rebuild search index
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'content/**'
+      - 'data/**'
+      - 'scripts/build-search.js'
+      - 'package.json'
+      - '.github/workflows/update-search.yml'
+
+jobs:
+  build-search:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - run: node scripts/build-search.js
+      - uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: 'chore(search): rebuild index'
+          file_pattern: public/search.en.json public/search.ar.json

--- a/CMS.md
+++ b/CMS.md
@@ -1,0 +1,65 @@
+# Private CMS Operations
+
+The Palestine site now includes a private, Git-backed CMS powered by Netlify CMS. This interface exists to make carefully-audited content changes without exposing an external surface to the public internet. Treat it like any other part of the organizing infrastructure: verify authentication, double check diffs, and keep Arabic/English parity tight.
+
+## Accessing `/admin`
+
+- The admin client lives at [`/admin`](./public/admin/index.html) and is not linked anywhere in the public UI.
+- Requests to `/admin` and `/api/cms/*` are gated behind HTTP Basic Auth. Credentials are injected through environment variables (`BASIC_AUTH_USER`, `BASIC_AUTH_PASS`). Browsers cache the credentials for the current origin once entered.
+- `robots.txt` explicitly disallows crawling `/admin` and `/api/cms`, reducing automated discovery.
+- Netlify CMS is manually initialised in the browser after fetching a protected config payload from `/api/cms/config`.
+
+## Environment variables
+
+Copy `.env.example` to `.env.local` (or your deployment secret store) and set:
+
+| Variable | Description |
+| --- | --- |
+| `BASIC_AUTH_USER` / `BASIC_AUTH_PASS` | Required for every request to `/admin` and `/api/cms/*`. |
+| `CMS_MODE` | `token` (single-user) or `oauth` (multi-user). |
+| `CMS_GITHUB_TOKEN` | Fine-grained GitHub token with repo contents scope (used when `CMS_MODE=token`). |
+| `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET` | OAuth app credentials (only when `CMS_MODE=oauth`). |
+| `CMS_ALLOWED_USERS` | Comma-separated list of email addresses authorised to log in via OAuth. Leave blank to allow anyone with Basic Auth + GitHub access. |
+| `CMS_GITHUB_REPO` (optional) | Override the GitHub repo slug if deploying to a fork. |
+| `CMS_GITHUB_BRANCH` (optional) | Override the branch used for commits. |
+
+### Token mode
+
+`CMS_MODE=token` injects the fine-grained token server-side. The token never leaves the protected API unless the requester has already passed Basic Auth. Use this for quick, single-user edits.
+
+### OAuth mode
+
+`CMS_MODE=oauth` enables a GitHub OAuth dance under `/api/cms/oauth/*`. The middleware still enforces Basic Auth so only trusted organisers can kick off the flow. The callback validates state, exchanges the code for a token, and (optionally) checks the resulting GitHub email against `CMS_ALLOWED_USERS`.
+
+GitHub scopes: the CMS requests `repo` to read/write content. Keep the OAuth app restricted to this project.
+
+## Collections & editing model
+
+The CMS exposes:
+
+- **Chapters (English)** and **Chapters (Arabic)** from `content/chapters`. New files are created with `.mdx` extensions, matching the existing bilingual pairing. Language is enforced through hidden frontmatter fields; always keep Arabic translations aligned with the corresponding English slug.
+- **Timeline — Content** (`content/timeline/*.yml`) for narrative milestones and **Timeline — Data** (`data/timeline/*.yml`) for shared or Arabic-enhanced events.
+- **Bibliography** (`data/bibliography.json`) and **Gazetteer** (`data/gazetteer.json`). Each entry is edited as structured JSON; the CMS ensures the files remain valid arrays.
+- **Media uploads** land in `public/images/uploads`. Move large media via git manually to avoid bloating the repo.
+
+Every save triggers Netlify CMS to commit directly to the configured branch using GitHub APIs. Review diffs before merging downstream.
+
+## Search index regeneration
+
+`scripts/build-search.js` rebuilds `public/search.en.json` and `public/search.ar.json`.
+
+- The script runs automatically before and after `npm run build`.
+- A GitHub Action (`Rebuild search index`) reruns the script on pushes touching `content/**`, `data/**`, or the script itself. If the generated JSON files change, the workflow commits them back to `main`.
+- Unit tests assert that chapter summaries remain synchronised with the search index; if you edit content locally, rerun `node scripts/build-search.js` before committing.
+
+## Local development notes
+
+- When running `npm run dev`, set at minimum `BASIC_AUTH_USER`, `BASIC_AUTH_PASS`, `CMS_MODE`, and either `CMS_GITHUB_TOKEN` or the OAuth credentials.
+- Playwright E2E tests supply dummy credentials automatically. For manual testing, export the same values so the middleware allows you through.
+- Netlify CMS is fetched from the unpkg CDN. When developing offline, expect the admin shell to display a warning until connectivity returns.
+
+## Incident response
+
+- If credentials leak, rotate both the Basic Auth password and the GitHub token/OAuth secret immediately, then invalidate outstanding sessions.
+- All CMS activity lands in Git history; use standard git revert workflows to roll back.
+- Treat the Basic Auth realm (`Palestine CMS`) as a signal—unexpected prompts indicate a potential probe. Monitor server logs accordingly.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ npm run test:e2e    # playwright
   ```bash
   npx playwright install --with-deps
   ```
+
+## Editing content via the private CMS
+
+Maintainers can edit chapters, timelines, bibliography entries, gazetteer data, and media through the secured Netlify CMS instance under `/admin`. The interface is protected with HTTP Basic Auth and a GitHub-backed workflow. See [CMS.md](CMS.md) for setup, environment variables, and editorial guidance.
   or skip e2e and run unit tests:
   ```bash
   npm run test:unit

--- a/app/api/cms/config/route.ts
+++ b/app/api/cms/config/route.ts
@@ -1,0 +1,310 @@
+import { NextResponse } from 'next/server';
+
+const DEFAULT_REPO = 'jp-dunlap/Palestine';
+const DEFAULT_BRANCH = process.env.CMS_GITHUB_BRANCH ?? process.env.VERCEL_GIT_COMMIT_REF ?? 'main';
+
+function parseMode() {
+  const value = (process.env.CMS_MODE ?? 'token').toLowerCase();
+  return value === 'oauth' ? 'oauth' : 'token';
+}
+
+function getTokenBackend() {
+  const token = process.env.CMS_GITHUB_TOKEN;
+  if (!token) {
+    throw new Error('CMS_GITHUB_TOKEN is required when CMS_MODE=token');
+  }
+
+  return {
+    name: 'github',
+    repo: process.env.CMS_GITHUB_REPO ?? DEFAULT_REPO,
+    branch: DEFAULT_BRANCH,
+    auth_type: 'token',
+    token,
+    use_graphql: false,
+  };
+}
+
+function getOAuthBackend(origin: string) {
+  if (!process.env.GITHUB_CLIENT_ID || !process.env.GITHUB_CLIENT_SECRET) {
+    throw new Error('GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET are required when CMS_MODE=oauth');
+  }
+
+  return {
+    name: 'github',
+    repo: process.env.CMS_GITHUB_REPO ?? DEFAULT_REPO,
+    branch: DEFAULT_BRANCH,
+    base_url: `${origin}/api/cms/oauth`,
+    auth_endpoint: 'authorize',
+    use_graphql: false,
+  };
+}
+
+function chapterFields(language: 'en' | 'ar') {
+  return [
+    { label: 'Title', name: 'title', widget: 'string' },
+    { label: 'Slug', name: 'slug', widget: 'string' },
+    { label: 'Era', name: 'era', widget: 'string', required: false },
+    {
+      label: 'Authors',
+      name: 'authors',
+      widget: 'list',
+      field: { label: 'Author', name: 'author', widget: 'string' },
+      required: false,
+    },
+    {
+      label: 'Language',
+      name: 'language',
+      widget: 'hidden',
+      default: language,
+    },
+    {
+      label: 'Summary',
+      name: 'summary',
+      widget: 'text',
+      required: false,
+    },
+    {
+      label: 'Date',
+      name: 'date',
+      widget: 'datetime',
+      time_format: false,
+      format: 'YYYY-MM-DD',
+      required: false,
+    },
+    {
+      label: 'Tags',
+      name: 'tags',
+      widget: 'list',
+      required: false,
+    },
+    {
+      label: 'Sources',
+      name: 'sources',
+      widget: 'list',
+      required: false,
+      fields: [
+        { label: 'Bibliography ID', name: 'id', widget: 'string', required: false },
+        { label: 'Source URL', name: 'url', widget: 'string', required: false },
+      ],
+    },
+    {
+      label: 'Places',
+      name: 'places',
+      widget: 'list',
+      required: false,
+    },
+    {
+      label: 'Body',
+      name: 'body',
+      widget: 'markdown',
+    },
+  ];
+}
+
+function timelineFields(includeArabic: boolean) {
+  const base = [
+    { label: 'ID', name: 'id', widget: 'string' },
+    { label: 'Title', name: 'title', widget: 'string' },
+    {
+      label: 'Title (Arabic)',
+      name: 'title_ar',
+      widget: 'string',
+      required: !includeArabic,
+      hint: 'Optional Arabic title for localisation.',
+      default: '',
+    },
+    {
+      label: 'Start Year',
+      name: 'start',
+      widget: 'number',
+      value_type: 'int',
+      hint: 'Negative numbers represent BCE years.',
+    },
+    {
+      label: 'End Year',
+      name: 'end',
+      widget: 'number',
+      value_type: 'int',
+      required: false,
+    },
+    {
+      label: 'Summary',
+      name: 'summary',
+      widget: 'text',
+      required: false,
+    },
+    {
+      label: 'Summary (Arabic)',
+      name: 'summary_ar',
+      widget: 'text',
+      required: !includeArabic,
+      default: '',
+    },
+    {
+      label: 'Places',
+      name: 'places',
+      widget: 'list',
+      required: false,
+    },
+    {
+      label: 'Sources',
+      name: 'sources',
+      widget: 'list',
+      field: { label: 'Reference', name: 'reference', widget: 'string' },
+      required: false,
+    },
+    {
+      label: 'Tags',
+      name: 'tags',
+      widget: 'list',
+      required: false,
+    },
+    {
+      label: 'Tags (Arabic)',
+      name: 'tags_ar',
+      widget: 'list',
+      required: !includeArabic,
+      default: [],
+    },
+    {
+      label: 'Certainty',
+      name: 'certainty',
+      widget: 'select',
+      options: [
+        { label: 'High confidence', value: 'high' },
+        { label: 'Medium confidence', value: 'medium' },
+        { label: 'Low confidence', value: 'low' },
+      ],
+      required: false,
+    },
+  ];
+
+  if (!includeArabic) {
+    return base.filter((field) => !['title_ar', 'summary_ar', 'tags_ar'].includes(field.name));
+  }
+
+  return base;
+}
+
+function bibliographyCollection() {
+  return {
+    name: 'bibliography',
+    label: 'Bibliography',
+    editor: { preview: false },
+    files: [
+      {
+        label: 'Bibliography Entries',
+        name: 'entries',
+        file: 'data/bibliography.json',
+        format: 'json',
+        fields: [
+          {
+            label: 'Entries',
+            name: 'entries',
+            widget: 'list',
+            label_singular: 'Entry',
+            field: {
+              label: 'CSL JSON Entry',
+              name: 'json',
+              widget: 'json',
+            },
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function gazetteerCollection() {
+  return {
+    name: 'gazetteer',
+    label: 'Gazetteer',
+    editor: { preview: false },
+    files: [
+      {
+        label: 'Gazetteer Entries',
+        name: 'places',
+        file: 'data/gazetteer.json',
+        format: 'json',
+        fields: [
+          {
+            label: 'Places',
+            name: 'entries',
+            widget: 'list',
+            label_singular: 'Place',
+            field: {
+              label: 'Place JSON',
+              name: 'json',
+              widget: 'json',
+            },
+          },
+        ],
+      },
+    ],
+  };
+}
+
+export async function GET(request: Request) {
+  try {
+    const url = new URL(request.url);
+    const mode = parseMode();
+
+    const backend = mode === 'token' ? getTokenBackend() : getOAuthBackend(url.origin);
+
+    const config = {
+      backend,
+      publish_mode: 'simple',
+      media_folder: 'public/images/uploads',
+      public_folder: '/images/uploads',
+      collections: [
+        {
+          name: 'chapters_en',
+          label: 'Chapters (English)',
+          label_singular: 'Chapter',
+          folder: 'content/chapters',
+          extension: 'mdx',
+          create: true,
+          filter: { field: 'language', value: 'en' },
+          slug: '{{slug}}',
+          fields: chapterFields('en'),
+        },
+        {
+          name: 'chapters_ar',
+          label: 'Chapters (Arabic)',
+          label_singular: 'Arabic Chapter',
+          folder: 'content/chapters',
+          extension: 'mdx',
+          create: true,
+          filter: { field: 'language', value: 'ar' },
+          slug: '{{slug}}.ar',
+          fields: chapterFields('ar'),
+        },
+        {
+          name: 'timeline_content',
+          label: 'Timeline — Content',
+          folder: 'content/timeline',
+          extension: 'yml',
+          create: true,
+          slug: '{{id}}',
+          fields: timelineFields(false),
+        },
+        {
+          name: 'timeline_data',
+          label: 'Timeline — Data',
+          folder: 'data/timeline',
+          extension: 'yml',
+          create: true,
+          slug: '{{id}}',
+          fields: timelineFields(true),
+        },
+        bibliographyCollection(),
+        gazetteerCollection(),
+      ],
+    } satisfies Record<string, unknown>;
+
+    return NextResponse.json(config);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'CMS configuration failed';
+    return new NextResponse(message, { status: 500 });
+  }
+}

--- a/app/api/cms/oauth/authorize/route.ts
+++ b/app/api/cms/oauth/authorize/route.ts
@@ -1,0 +1,52 @@
+import crypto from 'node:crypto';
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+const STATE_COOKIE = 'palestine_cms_oauth_state';
+
+function ensureOAuthMode() {
+  const mode = (process.env.CMS_MODE ?? 'token').toLowerCase();
+  if (mode !== 'oauth') {
+    throw new Error('OAuth mode is disabled. Set CMS_MODE=oauth to enable this endpoint.');
+  }
+}
+
+function requireClientId() {
+  const clientId = process.env.GITHUB_CLIENT_ID;
+  if (!clientId) {
+    throw new Error('GITHUB_CLIENT_ID is not configured.');
+  }
+  return clientId;
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    ensureOAuthMode();
+    const clientId = requireClientId();
+
+    const state = crypto.randomBytes(16).toString('hex');
+    const redirectUri = new URL('/api/cms/oauth/callback', request.nextUrl.origin).toString();
+
+    const authorizeUrl = new URL('https://github.com/login/oauth/authorize');
+    authorizeUrl.searchParams.set('client_id', clientId);
+    authorizeUrl.searchParams.set('scope', 'repo');
+    authorizeUrl.searchParams.set('state', state);
+    authorizeUrl.searchParams.set('redirect_uri', redirectUri);
+
+    const response = NextResponse.redirect(authorizeUrl.toString());
+    response.cookies.set({
+      name: STATE_COOKIE,
+      value: state,
+      httpOnly: true,
+      secure: true,
+      path: '/api/cms/oauth',
+      sameSite: 'lax',
+      maxAge: 60 * 5,
+    });
+
+    return response;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'OAuth authorization failed';
+    return new NextResponse(message, { status: 500 });
+  }
+}

--- a/app/api/cms/oauth/callback/route.ts
+++ b/app/api/cms/oauth/callback/route.ts
@@ -1,0 +1,142 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+const STATE_COOKIE = 'palestine_cms_oauth_state';
+const USER_AGENT = 'Palestine-CMS/1.0';
+
+function ensureOAuthMode() {
+  const mode = (process.env.CMS_MODE ?? 'token').toLowerCase();
+  if (mode !== 'oauth') {
+    throw new Error('OAuth mode is disabled. Set CMS_MODE=oauth to enable this endpoint.');
+  }
+}
+
+function requireSecrets() {
+  const clientId = process.env.GITHUB_CLIENT_ID;
+  const clientSecret = process.env.GITHUB_CLIENT_SECRET;
+  if (!clientId || !clientSecret) {
+    throw new Error('GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET must be set.');
+  }
+  return { clientId, clientSecret };
+}
+
+function parseAllowedUsers() {
+  const raw = process.env.CMS_ALLOWED_USERS;
+  if (!raw) return [];
+  return raw
+    .split(',')
+    .map((value) => value.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+function renderResult(message: string) {
+  return `<!DOCTYPE html><html><body><script>(function(){var payload=${JSON.stringify(
+    message,
+  )};if(window.opener){window.opener.postMessage(payload,'*');}window.close();})();</script></body></html>`;
+}
+
+async function fetchGitHubToken(code: string, redirectUri: string) {
+  const { clientId, clientSecret } = requireSecrets();
+
+  const response = await fetch('https://github.com/login/oauth/access_token', {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      'User-Agent': USER_AGENT,
+    },
+    body: JSON.stringify({ client_id: clientId, client_secret: clientSecret, code, redirect_uri: redirectUri }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`GitHub token exchange failed with status ${response.status}`);
+  }
+
+  const data = (await response.json()) as { access_token?: string; error?: string; error_description?: string };
+  if (!data.access_token) {
+    const description = data.error_description || data.error || 'Unknown OAuth error';
+    throw new Error(description);
+  }
+
+  return data.access_token;
+}
+
+async function fetchGitHubEmail(token: string) {
+  const userResponse = await fetch('https://api.github.com/user', {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'User-Agent': USER_AGENT,
+      Accept: 'application/json',
+    },
+  });
+
+  if (!userResponse.ok) {
+    throw new Error(`Unable to fetch GitHub user profile (status ${userResponse.status})`);
+  }
+
+  const user = (await userResponse.json()) as { email?: string | null };
+  if (user.email) {
+    return user.email.toLowerCase();
+  }
+
+  const emailsResponse = await fetch('https://api.github.com/user/emails', {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'User-Agent': USER_AGENT,
+      Accept: 'application/json',
+    },
+  });
+
+  if (!emailsResponse.ok) {
+    throw new Error(`Unable to fetch GitHub user emails (status ${emailsResponse.status})`);
+  }
+
+  const emails = (await emailsResponse.json()) as Array<{ email: string; primary?: boolean }>;
+  const primary = emails.find((entry) => entry.primary);
+  const first = (primary ?? emails[0])?.email;
+  if (!first) {
+    throw new Error('No GitHub email address found for this user.');
+  }
+
+  return first.toLowerCase();
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    ensureOAuthMode();
+    const params = request.nextUrl.searchParams;
+    const code = params.get('code');
+    const state = params.get('state');
+
+    if (!code || !state) {
+      throw new Error('Missing OAuth code or state.');
+    }
+
+    const storedState = request.cookies.get(STATE_COOKIE)?.value;
+    if (!storedState || storedState !== state) {
+      throw new Error('OAuth state verification failed. Please retry.');
+    }
+
+    const redirectUri = new URL('/api/cms/oauth/callback', request.nextUrl.origin).toString();
+    const token = await fetchGitHubToken(code, redirectUri);
+
+    const allowed = parseAllowedUsers();
+    if (allowed.length > 0) {
+      const email = await fetchGitHubEmail(token);
+      if (!allowed.includes(email)) {
+        throw new Error('This account is not permitted to publish edits.');
+      }
+    }
+
+    const payload = `authorization:github:success:${JSON.stringify({ token })}`;
+    const html = renderResult(payload);
+    const response = new NextResponse(html, { headers: { 'Content-Type': 'text/html' } });
+    response.cookies.set({ name: STATE_COOKIE, value: '', path: '/api/cms/oauth', maxAge: 0 });
+    return response;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'OAuth callback failed';
+    const payload = `authorization:github:failure:${JSON.stringify({ message })}`;
+    const html = renderResult(payload);
+    return new NextResponse(html, { headers: { 'Content-Type': 'text/html' }, status: 400 });
+  }
+}

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -4,7 +4,13 @@ import type { MetadataRoute } from 'next';
 export default function robots(): MetadataRoute.Robots {
   const base = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://palestine.example';
   return {
-    rules: [{ userAgent: '*', allow: '/' }],
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+        disallow: ['/admin', '/api/cms'],
+      },
+    ],
     sitemap: `${base}/sitemap.xml`,
   };
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+const REALM = 'Palestine CMS';
+
+function unauthorized() {
+  return new NextResponse('Unauthorized', {
+    status: 401,
+    headers: {
+      'WWW-Authenticate': `Basic realm="${REALM}"`,
+    },
+  });
+}
+
+export function middleware(request: NextRequest) {
+  const username = process.env.BASIC_AUTH_USER;
+  const password = process.env.BASIC_AUTH_PASS;
+
+  if (!username || !password) {
+    return new NextResponse('CMS authentication is not configured', { status: 500 });
+  }
+
+  const header = request.headers.get('authorization');
+  if (!header) {
+    return unauthorized();
+  }
+
+  const [scheme, value] = header.split(' ');
+  if (scheme !== 'Basic' || !value) {
+    return unauthorized();
+  }
+
+  let decoded: string;
+  try {
+    decoded = Buffer.from(value, 'base64').toString('utf8');
+  } catch {
+    return unauthorized();
+  }
+
+  const separatorIndex = decoded.indexOf(':');
+  if (separatorIndex === -1) {
+    return unauthorized();
+  }
+
+  const receivedUser = decoded.slice(0, separatorIndex);
+  const receivedPass = decoded.slice(separatorIndex + 1);
+
+  if (receivedUser !== username || receivedPass !== password) {
+    return unauthorized();
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/admin/:path*', '/api/cms/:path*'],
+};

--- a/package.json
+++ b/package.json
@@ -6,11 +6,12 @@
     "dev": "next dev",
     "prebuild": "node scripts/build-search.js",
     "build": "next build",
+    "postbuild": "node scripts/build-search.js",
     "start": "next start",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "test": "vitest",
     "test:unit": "vitest run",
-    "test:e2e": "playwright test"
+    "test:e2e": "BASIC_AUTH_USER=test BASIC_AUTH_PASS=secret CMS_MODE=token CMS_GITHUB_TOKEN=dummy playwright test"
   },
   "dependencies": {
     "@next/mdx": "^16.0.1",

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -1,0 +1,155 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Palestine — Private CMS</title>
+    <link rel="preconnect" href="https://unpkg.com" crossorigin />
+    <style>
+      :root {
+        color-scheme: dark light;
+      }
+      body {
+        margin: 0;
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: #0f172a;
+        color: #f8fafc;
+      }
+      .status {
+        padding: 2rem;
+        border-radius: 0.75rem;
+        max-width: 32rem;
+        text-align: center;
+        background: rgba(15, 23, 42, 0.85);
+        box-shadow: 0 25px 50px -12px rgba(15, 23, 42, 0.65);
+      }
+      .status h1 {
+        margin-top: 0;
+        font-size: 1.5rem;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+      }
+      .status p {
+        line-height: 1.5;
+        color: rgba(226, 232, 240, 0.9);
+      }
+    </style>
+    <script>
+      window.CMS_MANUAL_INIT = true;
+    </script>
+    <script src="https://unpkg.com/netlify-cms-app@^2.19.0/dist/netlify-cms.js"></script>
+  </head>
+  <body>
+    <div class="status" id="cms-status">
+      <h1>Palestine CMS</h1>
+      <p id="cms-status-message">Loading secure editor…</p>
+    </div>
+    <script type="module">
+      const statusEl = document.getElementById('cms-status');
+      const messageEl = document.getElementById('cms-status-message');
+
+      function updateStatus(text, isError = false) {
+        if (messageEl) {
+          messageEl.textContent = text;
+        }
+        if (isError && statusEl) {
+          statusEl.style.background = 'rgba(153, 27, 27, 0.85)';
+        }
+      }
+
+      async function fetchConfig() {
+        const response = await fetch('/api/cms/config', {
+          headers: { Accept: 'application/json' },
+        });
+
+        if (!response.ok) {
+          const errorText = await response.text();
+          throw new Error(errorText || `Unable to load CMS configuration (status ${response.status})`);
+        }
+
+        return response.json();
+      }
+
+      function registerJsonCollectionTransforms(CMS) {
+        const { fromJS, List, Map } = CMS?.utils?.Immutable ?? {};
+        const collections = new Set(['bibliography', 'gazetteer']);
+
+        if (!fromJS || !List || !Map) return;
+
+        CMS.registerEventListener({
+          name: 'postFetch',
+          handler: ({ entry }) => {
+            if (!entry) return entry;
+            const collection = entry.get('collection');
+            if (!collections.has(collection)) return entry;
+            const data = entry.get('data');
+            if (!List.isList(data)) return entry;
+            const wrapped = data.map((item) => ({ json: item?.toJS ? item.toJS() : item }));
+            return entry.set('data', fromJS({ entries: wrapped.toJS ? wrapped.toJS() : wrapped }));
+          },
+        });
+
+        CMS.registerEventListener({
+          name: 'preSave',
+          handler: ({ entry }) => {
+            if (!entry) return entry;
+            const collection = entry.get('collection');
+            if (!collections.has(collection)) return entry;
+            const data = entry.get('data');
+            if (!Map.isMap(data)) return entry;
+            const entries = data.get('entries');
+            if (!List.isList(entries)) return entry;
+
+            const parsed = entries
+              .map((item) => {
+                const value = item?.get ? item.get('json') : item?.json;
+                if (typeof value === 'string') {
+                  try {
+                    return JSON.parse(value);
+                  } catch (err) {
+                    throw new Error(`Invalid JSON detected: ${err.message}`);
+                  }
+                }
+                return value?.toJS ? value.toJS() : value;
+              })
+              .toArray();
+
+            return entry.set('data', fromJS(parsed));
+          },
+        });
+      }
+
+      async function init() {
+        try {
+          const config = await fetchConfig();
+          const { CMS } = window;
+          if (!CMS) {
+            throw new Error('Netlify CMS failed to load. Check the CDN script.');
+          }
+
+          registerJsonCollectionTransforms(CMS);
+
+          CMS.init({ config });
+          updateStatus('Authenticated. Loading collections…');
+          CMS.registerEventListener({
+            name: 'preSave',
+            handler: () => updateStatus('Saving changes…'),
+          });
+          CMS.registerEventListener({
+            name: 'postSave',
+            handler: () => updateStatus('Changes saved to Git.'),
+          });
+        } catch (error) {
+          console.error('[cms] initialization error', error);
+          updateStatus(error.message || 'CMS failed to load.', true);
+        }
+      }
+
+      init();
+    </script>
+  </body>
+</html>

--- a/tests/e2e/admin-auth.spec.ts
+++ b/tests/e2e/admin-auth.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('admin access control', () => {
+  test('rejects unauthenticated visitors', async ({ request }) => {
+    const response = await request.get('/admin');
+    expect(response.status()).toBe(401);
+  });
+
+  test('allows authenticated access to the CMS shell', async ({ browser }, testInfo) => {
+    const baseURL = testInfo.project.use.baseURL;
+    const context = await browser.newContext({
+      baseURL,
+      httpCredentials: {
+        username: 'test',
+        password: 'secret',
+      },
+    });
+
+    const page = await context.newPage();
+    const response = await page.goto('/admin');
+    expect(response?.status()).toBe(200);
+
+    await expect(page.locator('#cms-status h1')).toHaveText(/Palestine CMS/i);
+    await expect(page.locator('#cms-status-message')).toContainText('Loading secure editor');
+
+    await context.close();
+  });
+});

--- a/tests/e2e/robots.spec.ts
+++ b/tests/e2e/robots.spec.ts
@@ -9,6 +9,7 @@ test.describe('robots.txt', () => {
 
     expect(body).toMatch(/User-agent:\s*\*/i);
     expect(body).toMatch(/Allow:\s*\//i);
+    expect(body).toMatch(/Disallow:\s*\/admin/i);
     expect(body).toMatch(/Sitemap:\s*(https?:\/\/[^\s]+)?\/sitemap\.xml/i);
   });
 });

--- a/tests/unit/search-index.test.ts
+++ b/tests/unit/search-index.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import matter from 'gray-matter';
+
+const ROOT = process.cwd();
+
+function resolve(...segments: string[]) {
+  return path.join(ROOT, ...segments);
+}
+
+describe('search index regeneration', () => {
+  it('captures updated chapter summaries in the search index', async () => {
+    const chapterPath = resolve('content', 'chapters', '001-prologue.mdx');
+    const indexPath = resolve('public', 'search.en.json');
+
+    const [chapterRaw, indexRaw] = await Promise.all([
+      fs.readFile(chapterPath, 'utf8'),
+      fs.readFile(indexPath, 'utf8'),
+    ]);
+
+    const { data } = matter(chapterRaw);
+    const docs = JSON.parse(indexRaw) as Array<Record<string, unknown>>;
+    const entry = docs.find((doc) => doc && doc.href === '/chapters/001-prologue');
+
+    expect(entry).toBeTruthy();
+    expect(entry?.summary).toBe(data.summary);
+  });
+});


### PR DESCRIPTION
## Summary
- add HTTP basic auth middleware and a manually initialised Netlify CMS admin shell under `/admin`
- expose CMS configuration and OAuth/token backends from protected Next.js API routes and document usage in CMS.md and README
- automate search index regeneration via postbuild hook and GitHub Action, plus add tests covering basic auth, robots, and search index parity

## Testing
- npm run typecheck
- npm run test:unit
- npm run build
- npm run test:e2e *(fails: Playwright browsers unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_b_6907efe7ed948320a2cf64ff5a2bbe25