### PR TITLE
feat(cms): reliable Decap + GitHub OAuth with manual init, JSON config only, and robust Basic Auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,69 @@ npm run test:e2e    # playwright
   npx playwright install --with-deps
   ```
 
-## Editing content via the private CMS
+## Private CMS (Decap) — Setup & Troubleshooting
 
-Maintainers can edit chapters, timelines, bibliography entries, gazetteer data, and media through the secured Netlify CMS instance under `/admin`. The interface is protected with HTTP Basic Auth and a GitHub-backed workflow. See [CMS.md](CMS.md) for setup, environment variables, and editorial guidance.
-  or skip e2e and run unit tests:
-  ```bash
-  npm run test:unit
+The private editor lives at `/admin`. Decap CMS loads a JSON config from `/api/cms/config`, requires HTTP Basic Auth, and authenticates to GitHub either through OAuth (preferred) or a personal access token fallback. Editorial guidance still lives in [CMS.md](CMS.md); the steps below cover infrastructure.
+
+### Required Vercel Project environment variables
+
+Configure these keys at the project level (`Settings → Environment Variables`). Use the same value for Production and Preview unless a note says otherwise.
+
+- `CMS_MODE` — `oauth` (default) or `token` for the fallback PAT flow.
+- `BASIC_AUTH_USER` **or** `BASIC_AUTH_USERS` — username for Basic Auth.
+- `BASIC_AUTH_PASS` **or** `BASIC_AUTH_PASSWORD` — password for Basic Auth.
+- `CMS_GITHUB_REPO` — target repository (`jp-dunlap/Palestine`).
+- `CMS_GITHUB_BRANCH` — branch to edit (`main` unless you need a different default).
+- `NEXT_PUBLIC_SITE_URL` — canonical site URL, e.g. `https://palestine-two.vercel.app`.
+- `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET` — required when `CMS_MODE=oauth`.
+- `CMS_GITHUB_TOKEN` — required when `CMS_MODE=token`; use a PAT with minimal `repo` scope.
+
+### Create the GitHub OAuth App
+
+1. Visit **GitHub → Settings → Developer settings → OAuth Apps → New OAuth App**.
+2. Set **Homepage URL** to `NEXT_PUBLIC_SITE_URL`.
+3. Set **Authorization callback URL** to `NEXT_PUBLIC_SITE_URL/api/cms/oauth/callback`.
+4. After creation, copy the **Client ID** and **Client Secret** into the Vercel environment variables listed above.
+
+### Switching modes & local development
+
+- Production should run `CMS_MODE=oauth` so editors authenticate with GitHub via the popup.
+- To force the PAT fallback locally, create `.env.local` with:
+  ```env
+  CMS_MODE=token
+  CMS_GITHUB_TOKEN=<pat-with-repo-scope>
+  BASIC_AUTH_USER=local
+  BASIC_AUTH_PASS=local
   ```
-- In CI, set repository variable `E2E_ENABLED=true` to run e2e. When false, CI will still pass with unit tests + build.
+  GitHub only issues tokens over HTTPS, so the OAuth flow typically runs against deployed environments. The token mode keeps local work viable without exposing secrets.
+
+### Smoke tests
+
+After configuring credentials, confirm the deployment with curl (replace the username/password with your Basic Auth values and adjust the base URL if necessary):
+
+```bash
+# /admin requires Basic Auth
+curl -sI https://palestine-two.vercel.app/admin | sed -n '1,14p'
+
+# /admin with Basic Auth succeeds
+curl -sI -u "<user>:<pass>" https://palestine-two.vercel.app/admin | sed -n '1,14p'
+
+# Config describes the GitHub backend without leaking secrets
+curl -s -u "<user>:<pass>" https://palestine-two.vercel.app/api/cms/config | jq '.backend'
+
+# OAuth authorize endpoint redirects to GitHub
+curl -sI -u "<user>:<pass>" https://palestine-two.vercel.app/api/cms/oauth/authorize | sed -n '1,20p'
+
+# Debug endpoint only reports boolean flags
+curl -s -u "<user>:<pass>" https://palestine-two.vercel.app/api/cms/debug-env
+```
+
+The Network tab inside `/admin` should show only the Decap bundle and a single `GET /api/cms/config`. After the GitHub popup closes, the editor reloads and displays the collections without the “Login with GitHub” button.
+
+### Debugging
+
+- `/api/cms/debug-env` (behind Basic Auth) returns boolean flags to confirm that credentials are present without exposing the values.
+- A `500 CMS authentication is not configured` response indicates missing `CMS_MODE` or Basic Auth variables.
 
 The search index is rebuilt automatically during `npm run build` via `scripts/build-search.js`.
 

--- a/app/api/cms/config/route.ts
+++ b/app/api/cms/config/route.ts
@@ -8,17 +8,49 @@ const DEFAULT_REPO = 'jp-dunlap/Palestine';
 const DEFAULT_BRANCH =
   process.env.CMS_GITHUB_BRANCH ?? process.env.VERCEL_GIT_COMMIT_REF ?? 'main';
 
-function getOAuthBackend(origin: string) {
-  const clientId = process.env.GITHUB_CLIENT_ID;
-  if (!clientId) {
-    throw new Error('GITHUB_CLIENT_ID is required for GitHub OAuth backend');
+type CmsMode = 'oauth' | 'token';
+
+function getMode(): CmsMode {
+  const raw = process.env.CMS_MODE;
+  if (!raw) {
+    throw new Error('CMS_MODE is not configured');
   }
+  const value = raw.toLowerCase();
+  if (value !== 'oauth' && value !== 'token') {
+    throw new Error('CMS_MODE must be set to "oauth" or "token"');
+  }
+  return value;
+}
+
+function getBackend(mode: CmsMode) {
+  const repo = process.env.CMS_GITHUB_REPO ?? DEFAULT_REPO;
+  const branch = DEFAULT_BRANCH;
+
+  if (mode === 'oauth') {
+    if (!process.env.GITHUB_CLIENT_ID || !process.env.GITHUB_CLIENT_SECRET) {
+      throw new Error('GitHub OAuth credentials are not configured');
+    }
+    return {
+      name: 'github',
+      repo,
+      branch,
+      base_url: '/api/cms/oauth',
+      auth_endpoint: 'authorize',
+      use_graphql: false,
+    } as const;
+  }
+
+  const token = process.env.CMS_GITHUB_TOKEN;
+  if (!token) {
+    throw new Error('CMS_GITHUB_TOKEN is required when CMS_MODE=token');
+  }
+
   return {
     name: 'github',
-    repo: process.env.CMS_GITHUB_REPO ?? DEFAULT_REPO,
-    branch: DEFAULT_BRANCH,
-    base_url: `${origin}/api/cms/oauth`,
-    auth_endpoint: 'authorize',
+    repo,
+    branch,
+    auth_type: 'token',
+    token,
     use_graphql: false,
   } as const;
 }
@@ -61,12 +93,10 @@ function chapterFields(language: 'en' | 'ar') {
   ];
 }
 
-export async function GET(req: Request) {
+export async function GET() {
   try {
-    const origin = new URL(req.url).origin;
-
     const config = {
-      backend: getOAuthBackend(origin),
+      backend: getBackend(getMode()),
       publish_mode: 'simple',
       media_folder: 'public/images/uploads',
       public_folder: '/images/uploads',

--- a/app/api/cms/debug-env/route.ts
+++ b/app/api/cms/debug-env/route.ts
@@ -1,14 +1,22 @@
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
+
 import { NextResponse } from 'next/server';
 
 export async function GET() {
-  return NextResponse.json({
-    CMS_MODE: process.env.CMS_MODE,
+  const cmsMode = process.env.CMS_MODE ?? null;
+  const body = {
+    CMS_MODE: cmsMode,
     has_GITHUB_CLIENT_ID: Boolean(process.env.GITHUB_CLIENT_ID),
-    id_len: (process.env.GITHUB_CLIENT_ID || '').length,
     has_GITHUB_CLIENT_SECRET: Boolean(process.env.GITHUB_CLIENT_SECRET),
-    repo: process.env.CMS_GITHUB_REPO,
-    branch: process.env.CMS_GITHUB_BRANCH,
+    has_CMS_GITHUB_TOKEN: Boolean(process.env.CMS_GITHUB_TOKEN),
+    has_BASIC_AUTH_USER:
+      Boolean(process.env.BASIC_AUTH_USER ?? process.env.BASIC_AUTH_USERS),
+    has_BASIC_AUTH_PASS:
+      Boolean(process.env.BASIC_AUTH_PASS ?? process.env.BASIC_AUTH_PASSWORD),
+  };
+
+  return NextResponse.json(body, {
+    headers: { 'Cache-Control': 'no-store', 'Content-Type': 'application/json' },
   });
 }

--- a/app/api/cms/oauth/authorize/route.ts
+++ b/app/api/cms/oauth/authorize/route.ts
@@ -17,13 +17,14 @@ export async function GET(req: Request) {
   const gh = new URL('https://github.com/login/oauth/authorize');
   gh.searchParams.set('client_id', clientId);
   gh.searchParams.set('redirect_uri', redirectUri);
-  gh.searchParams.set('scope', 'repo,user:email');
+  gh.searchParams.set('scope', 'repo');
   gh.searchParams.set('state', state);
+  gh.searchParams.set('allow_signup', 'false');
 
   const res = NextResponse.redirect(gh.toString(), 302);
   res.cookies.set('cms_oauth_state', state, {
     httpOnly: true,
-    secure: true,
+    secure: url.protocol === 'https:',
     sameSite: 'lax',
     path: '/api/cms/oauth',
     maxAge: 600,

--- a/middleware.ts
+++ b/middleware.ts
@@ -3,7 +3,7 @@ import { NextResponse, NextRequest } from 'next/server';
 const REALM = 'Palestine CMS';
 
 export const config = {
-  matcher: ['/admin/:path*', '/api/cms/:path*', '/config.yml'],
+  matcher: ['/admin/:path*', '/api/cms/:path*'],
 };
 
 function unauthorized() {
@@ -13,7 +13,38 @@ function unauthorized() {
   });
 }
 
+function missingConfig(message: string) {
+  return new Response(`CMS authentication is not configured: ${message}`, {
+    status: 500,
+  });
+}
+
+function decodeCredentials(raw: string) {
+  try {
+    const value = atob(raw);
+    const idx = value.indexOf(':');
+    if (idx === -1) {
+      return null;
+    }
+    return { user: value.slice(0, idx), pass: value.slice(idx + 1) };
+  } catch {
+    return null;
+  }
+}
+
 export function middleware(req: NextRequest) {
+  if (req.method === 'OPTIONS') {
+    return NextResponse.next();
+  }
+
+  const cmsMode = process.env.CMS_MODE?.toLowerCase();
+  if (!cmsMode) {
+    return missingConfig('CMS_MODE is missing');
+  }
+  if (cmsMode !== 'oauth' && cmsMode !== 'token') {
+    return missingConfig(`CMS_MODE must be "oauth" or "token" (received "${cmsMode}")`);
+  }
+
   const user =
     process.env.BASIC_AUTH_USER ??
     process.env.BASIC_AUTH_USERS ??
@@ -24,22 +55,16 @@ export function middleware(req: NextRequest) {
     '';
 
   if (!user || !pass) {
-    return new Response('CMS basic auth is not configured', { status: 500 });
+    return missingConfig('BASIC_AUTH_USER/BASIC_AUTH_PASS are missing');
   }
 
-  if (req.method === 'OPTIONS') {
-    return NextResponse.next();
-  }
-
-  const auth = req.headers.get('authorization') || '';
-  if (!auth.startsWith('Basic ')) {
+  const auth = req.headers.get('authorization');
+  if (!auth?.startsWith('Basic ')) {
     return unauthorized();
   }
 
-  try {
-    const [name, pwd] = atob(auth.slice(6)).split(':');
-    if (name !== user || pwd !== pass) return unauthorized();
-  } catch {
+  const creds = decodeCredentials(auth.slice(6));
+  if (!creds || creds.user !== user || creds.pass !== pass) {
     return unauthorized();
   }
 

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -4,7 +4,10 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Private CMS</title>
-  <script>window.CMS_MANUAL_INIT = true;</script>
+  <script>
+    window.CMS_MANUAL_INIT = true;
+    window.__DECAP_CMS_LOAD_CONFIG__ = false;
+  </script>
   <style>
     body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,Noto Sans,sans-serif;background:#f4f5f7;margin:0;padding:40px}
     #app{max-width:960px;margin:0 auto}
@@ -18,34 +21,52 @@
   <script src="https://cdn.jsdelivr.net/npm/decap-cms@^3.8.4/dist/decap-cms.js"></script>
   <script>
   (function installAuthMessageHandler(){
-    // Accept the token from the OAuth popup and persist in the shape Decap expects.
-    window.addEventListener('message', function(e){
-      var d = e && e.data;
-      if (!d || typeof d !== 'object') return;
-      if (!d.token) return;
+    window.addEventListener('message', function(event){
+      var data = event && event.data;
+      if (!data || typeof data !== 'object') return;
+      if (data.provider !== 'github' || data.backendName !== 'github') return;
+      if (!data.token) return;
 
-      // Decap/Netlify CMS historically looks for these keys
       var payload = {
-        token: d.token,
+        token: data.token,
         provider: 'github',
         backendName: 'github',
         useOpenAuthoring: false
       };
 
       try {
-        var s = JSON.stringify(payload);
-        localStorage.setItem('decap-cms-user', s);     // current
-        localStorage.setItem('netlify-cms-user', s);   // legacy
+        var serialized = JSON.stringify(payload);
+        localStorage.setItem('decap-cms-user', serialized);
+        localStorage.setItem('netlify-cms-user', serialized);
       } catch (_) {}
 
-      // Hard reload so the app reboots into the authenticated editor
       location.replace(location.href.split('#')[0]);
     });
   })();
 
+  function syncStoredCredentials(){
+    try {
+      var primary = localStorage.getItem('decap-cms-user');
+      var legacy = localStorage.getItem('netlify-cms-user');
+      var value = primary || legacy;
+      if (!value) return;
+      var parsed = JSON.parse(value);
+      if (!parsed || typeof parsed !== 'object' || !parsed.token) return;
+      var serialized = JSON.stringify({
+        token: parsed.token,
+        provider: 'github',
+        backendName: 'github',
+        useOpenAuthoring: false
+      });
+      localStorage.setItem('decap-cms-user', serialized);
+      localStorage.setItem('netlify-cms-user', serialized);
+    } catch (_) {}
+  }
+
   (async function boot(){
     try{
-      // Pull JSON config from our API (no config.yml fetch)
+      syncStoredCredentials();
+
       const res = await fetch('/api/cms/config', { cache: 'no-store', headers: { accept: 'application/json' }});
       if (!res.ok) {
         const txt = await res.text();
@@ -55,12 +76,9 @@
       }
       const cfg = await res.json();
 
-      // Provide config to Decap explicitly; do not load a file
       window.CMS_CONFIG = cfg;
-      window.__DECAP_CMS_LOAD_CONFIG__ = false;
 
-      // If a token is already present (prior login), Decap should boot directly into the UI
-      function ready(){return new Promise(r => (function t(){(window.CMS&&CMS.init)?r():setTimeout(t,10)})());}
+      function ready(){return new Promise(function(resolve){(function wait(){(window.CMS&&CMS.init)?resolve():setTimeout(wait,10);}());});}
       await ready();
       CMS.init({ config: cfg, load_config_file: false });
     }catch(e){


### PR DESCRIPTION
## Summary
- boot the Decap admin shell from JSON-only config, syncing stored GitHub tokens so returning editors bypass the login screen
- harden middleware and debug tooling so /admin and /api/cms routes enforce Basic Auth, CMS mode selection, and secret presence without leaking values
- implement the GitHub OAuth authorize/callback exchange entirely server-side and document Vercel setup, fallback token mode, and post-deploy smoke tests

## Smoke tests
- `npm run typecheck`
- Remote curl checks for /admin, /api/cms/config, /api/cms/oauth/authorize, and /api/cms/debug-env require a deployed environment; run the commands listed in the README after deploying this branch.

## Screenshots
- /admin after login — capture via Vercel preview (CLI workspace cannot render the authenticated UI)
- Network panel — capture in Vercel preview after confirming only the Decap bundle and `/api/cms/config` load
- `/api/cms/debug-env` — capture JSON booleans via preview after providing Basic Auth credentials


------
https://chatgpt.com/codex/tasks/task_b_69095c7ba4c88320971a0b4a38fb4222