### PR TITLE
feat(cms): reliable Decap + GitHub OAuth with manual init, JSON config only, and robust Basic Auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,57 @@ npm run test:e2e    # playwright
   npx playwright install --with-deps
   ```
 
-## Editing content via the private CMS
+## Private CMS (Decap) — Setup & Troubleshooting
 
-Maintainers can edit chapters, timelines, bibliography entries, gazetteer data, and media through the secured Netlify CMS instance under `/admin`. The interface is protected with HTTP Basic Auth and a GitHub-backed workflow. See [CMS.md](CMS.md) for setup, environment variables, and editorial guidance.
-  or skip e2e and run unit tests:
-  ```bash
-  npm run test:unit
-  ```
-- In CI, set repository variable `E2E_ENABLED=true` to run e2e. When false, CI will still pass with unit tests + build.
+We ship a private Decap CMS instance at `/admin` with manual JSON config loading and GitHub-backed authentication. The CMS never requests `config.yml`; all configuration comes from `/api/cms/config`.
+
+### Required Vercel Project environment variables
+
+Set these keys at the **project** level (not the account level) in Vercel:
+
+- `CMS_MODE` — `oauth` (GitHub OAuth, default) or `token` (fallback with PAT)
+- `BASIC_AUTH_USER` **and** `BASIC_AUTH_PASS` *(or `BASIC_AUTH_USERS` / `BASIC_AUTH_PASSWORD`)*
+- `CMS_GITHUB_REPO` (e.g., `jp-dunlap/Palestine`)
+- `CMS_GITHUB_BRANCH` (e.g., `main`)
+- `NEXT_PUBLIC_SITE_URL` (e.g., `https://palestine-two.vercel.app`)
+- OAuth mode: `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`
+- Token mode: `CMS_GITHUB_TOKEN` (GitHub PAT with minimal `repo` scope)
+
+Missing credentials will surface as HTTP 500 responses from either the middleware or `/api/cms/config`.
+
+### GitHub OAuth App setup
+
+1. Create a GitHub OAuth App under the `jp-dunlap` org or your personal account.
+2. Authorization callback URL: `https://palestine-two.vercel.app/api/cms/oauth/callback`
+3. Set the homepage URL to the public site (e.g., `https://palestine-two.vercel.app`).
+4. Copy the **Client ID** and **Client Secret** into the Vercel env vars listed above.
+
+During local development you can run `npm run dev` with a `.env.local` file that sets the same variables (adjust the callback URL to match your localhost origin).
+
+### Smoke tests
+
+After deploying, validate the private CMS with:
+
+```bash
+# /admin unauthenticated
+curl -sI https://palestine-two.vercel.app/admin | sed -n '1,14p'
+
+# /admin with Basic Auth
+curl -sI -u "<user>:<pass>" https://palestine-two.vercel.app/admin | sed -n '1,14p'
+
+# Config endpoint (should show the OAuth backend in production)
+curl -s -u "<user>:<pass>" https://palestine-two.vercel.app/api/cms/config | jq '.backend'
+
+# OAuth authorize (302 to GitHub)
+curl -sI -u "<user>:<pass>" https://palestine-two.vercel.app/api/cms/oauth/authorize | sed -n '1,20p'
+
+# Debug flags (no secrets)
+curl -s -u "<user>:<pass>" https://palestine-two.vercel.app/api/cms/debug-env
+```
+
+### Token mode fallback
+
+If GitHub OAuth becomes unavailable, set `CMS_MODE=token` and provide `CMS_GITHUB_TOKEN`. The `/api/cms/config` response will embed the token directly for Decap. Remember to rotate the PAT regularly and revert to `CMS_MODE=oauth` once OAuth is back online.
 
 The search index is rebuilt automatically during `npm run build` via `scripts/build-search.js`.
 

--- a/app/api/cms/config/route.ts
+++ b/app/api/cms/config/route.ts
@@ -34,7 +34,7 @@ function getOAuthBackend(origin: string) {
   } as const;
 }
 
-function getTokenBackend() {
+function getTokenBackend(origin: string) {
   const token = process.env.CMS_GITHUB_TOKEN;
   if (!token) {
     throw new Error('CMS_GITHUB_TOKEN is required when CMS_MODE=token');
@@ -44,8 +44,8 @@ function getTokenBackend() {
     repo: process.env.CMS_GITHUB_REPO ?? DEFAULT_REPO,
     branch: DEFAULT_BRANCH,
     auth_type: 'token',
-    token,
     use_graphql: false,
+    token_endpoint: `${origin}/api/cms/token`,
   } as const;
 }
 
@@ -92,7 +92,8 @@ export async function GET(req: Request) {
     const origin = new URL(req.url).origin;
     const mode = getMode();
 
-    const backend = mode === 'oauth' ? getOAuthBackend(origin) : getTokenBackend();
+    const backend =
+      mode === 'oauth' ? getOAuthBackend(origin) : getTokenBackend(origin);
 
     const config = {
       backend,

--- a/app/api/cms/debug-env/route.ts
+++ b/app/api/cms/debug-env/route.ts
@@ -1,14 +1,23 @@
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
+
 import { NextResponse } from 'next/server';
 
 export async function GET() {
-  return NextResponse.json({
-    CMS_MODE: process.env.CMS_MODE,
-    has_GITHUB_CLIENT_ID: Boolean(process.env.GITHUB_CLIENT_ID),
-    id_len: (process.env.GITHUB_CLIENT_ID || '').length,
-    has_GITHUB_CLIENT_SECRET: Boolean(process.env.GITHUB_CLIENT_SECRET),
-    repo: process.env.CMS_GITHUB_REPO,
-    branch: process.env.CMS_GITHUB_BRANCH,
-  });
+  const modeValue = (process.env.CMS_MODE ?? '').toLowerCase();
+  const mode = modeValue === 'oauth' || modeValue === 'token' ? modeValue : null;
+
+  return NextResponse.json(
+    {
+      CMS_MODE: mode,
+      has_GITHUB_CLIENT_ID: Boolean(process.env.GITHUB_CLIENT_ID),
+      has_GITHUB_CLIENT_SECRET: Boolean(process.env.GITHUB_CLIENT_SECRET),
+      has_PAT: Boolean(process.env.CMS_GITHUB_TOKEN),
+      has_basic_auth_user:
+        Boolean(process.env.BASIC_AUTH_USER) || Boolean(process.env.BASIC_AUTH_USERS),
+      has_basic_auth_password:
+        Boolean(process.env.BASIC_AUTH_PASS) || Boolean(process.env.BASIC_AUTH_PASSWORD),
+    },
+    { headers: { 'Cache-Control': 'no-store' } }
+  );
 }

--- a/app/api/cms/oauth/authorize/route.ts
+++ b/app/api/cms/oauth/authorize/route.ts
@@ -17,13 +17,14 @@ export async function GET(req: Request) {
   const gh = new URL('https://github.com/login/oauth/authorize');
   gh.searchParams.set('client_id', clientId);
   gh.searchParams.set('redirect_uri', redirectUri);
-  gh.searchParams.set('scope', 'repo,user:email');
+  gh.searchParams.set('scope', 'repo');
   gh.searchParams.set('state', state);
+  gh.searchParams.set('allow_signup', 'false');
 
   const res = NextResponse.redirect(gh.toString(), 302);
   res.cookies.set('cms_oauth_state', state, {
     httpOnly: true,
-    secure: true,
+    secure: url.protocol === 'https:',
     sameSite: 'lax',
     path: '/api/cms/oauth',
     maxAge: 600,

--- a/app/api/cms/token/route.ts
+++ b/app/api/cms/token/route.ts
@@ -1,0 +1,54 @@
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+import { NextResponse } from 'next/server';
+
+type CMSMode = 'oauth' | 'token';
+
+function getMode(): CMSMode {
+  const value = (process.env.CMS_MODE ?? '').toLowerCase();
+  if (value === 'oauth' || value === 'token') {
+    return value;
+  }
+  throw new Error('CMS_MODE must be set to "oauth" or "token"');
+}
+
+function assertTokenAvailable() {
+  const token = process.env.CMS_GITHUB_TOKEN;
+  if (!token) {
+    throw new Error('CMS_GITHUB_TOKEN is required when CMS_MODE=token');
+  }
+  return token;
+}
+
+export async function GET() {
+  try {
+    const mode = getMode();
+    if (mode !== 'token') {
+      return NextResponse.json(
+        { error: 'CMS token mode is not enabled' },
+        {
+          status: 400,
+          headers: { 'Cache-Control': 'no-store' },
+        },
+      );
+    }
+
+    const token = assertTokenAvailable();
+    return NextResponse.json(
+      { token },
+      {
+        status: 200,
+        headers: { 'Cache-Control': 'no-store' },
+      },
+    );
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : 'Unexpected CMS token error';
+    return new NextResponse(message, {
+      status: 500,
+      headers: { 'Cache-Control': 'no-store', 'Content-Type': 'text/plain' },
+    });
+  }
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -40,6 +40,11 @@ export function middleware(req: NextRequest) {
     return missingAuthConfig('CMS authentication mode is not configured');
   }
 
+  const normalizedMode = mode.toLowerCase();
+  if (normalizedMode !== 'oauth' && normalizedMode !== 'token') {
+    return missingAuthConfig('CMS authentication mode is invalid');
+  }
+
   const auth = req.headers.get('authorization') || '';
   if (!auth.startsWith('Basic ')) {
     return unauthorized();

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -56,6 +56,50 @@
 
   <script src="https://cdn.jsdelivr.net/npm/decap-cms@^3.8.4/dist/decap-cms.js"></script>
   <script>
+    function ensureUseOpenAuthoring(payload) {
+      if (payload && typeof payload.useOpenAuthoring === 'undefined') {
+        payload.useOpenAuthoring = false;
+      }
+      return payload;
+    }
+
+    function persistUser(payload) {
+      ensureUseOpenAuthoring(payload);
+      try {
+        var serialized = JSON.stringify(payload);
+        localStorage.setItem('decap-cms-user', serialized);
+        localStorage.setItem('netlify-cms-user', serialized);
+      } catch (_) {}
+    }
+
+    function parseStoredUser(value) {
+      if (!value) return null;
+      try {
+        var parsed = JSON.parse(value);
+        if (parsed && typeof parsed === 'object' && parsed.token) {
+          return ensureUseOpenAuthoring(parsed);
+        }
+      } catch (_) {}
+      return null;
+    }
+
+    function readStoredUser() {
+      try {
+        var decap = parseStoredUser(localStorage.getItem('decap-cms-user'));
+        if (decap) return decap;
+        return parseStoredUser(localStorage.getItem('netlify-cms-user'));
+      } catch (_) {
+        return null;
+      }
+    }
+
+    function clearStoredUser() {
+      try {
+        localStorage.removeItem('decap-cms-user');
+        localStorage.removeItem('netlify-cms-user');
+      } catch (_) {}
+    }
+
     (function installAuthMessageHandler() {
       window.addEventListener('message', function (event) {
         var payload = event && event.data;
@@ -63,12 +107,7 @@
         if (!payload.token) return;
         if (payload.provider !== 'github' || payload.backendName !== 'github') return;
 
-        try {
-          var serialized = JSON.stringify(payload);
-          localStorage.setItem('decap-cms-user', serialized);
-          localStorage.setItem('netlify-cms-user', serialized);
-        } catch (_) {}
-
+        persistUser(payload);
         location.replace(location.href.split('#')[0]);
       });
     })();
@@ -76,17 +115,11 @@
     (function installLogoutHandler() {
       var button = document.querySelector('button.logout');
       if (!button) return;
-      try {
-        var stored = localStorage.getItem('decap-cms-user') || localStorage.getItem('netlify-cms-user');
-        if (stored) {
-          button.style.display = 'inline-block';
-        }
-      } catch (_) {}
+      if (readStoredUser()) {
+        button.style.display = 'inline-block';
+      }
       button.addEventListener('click', function () {
-        try {
-          localStorage.removeItem('decap-cms-user');
-          localStorage.removeItem('netlify-cms-user');
-        } catch (_) {}
+        clearStoredUser();
         location.replace(location.href.split('#')[0]);
       });
     })();
@@ -105,6 +138,43 @@
         }
         var config = await res.json();
         window.CMS_CONFIG = config;
+
+        async function ensureToken(config) {
+          if (!config || !config.backend) return;
+          var backend = config.backend;
+          if (backend.auth_type !== 'token') return;
+
+          var user = readStoredUser();
+          if (user) {
+            persistUser(user);
+          } else {
+            var tokenEndpoint = backend.token_endpoint || '/api/cms/token';
+            var tokenResponse = await fetch(tokenEndpoint, {
+              cache: 'no-store',
+              headers: { accept: 'application/json' },
+            });
+            if (!tokenResponse.ok) {
+              var tokenText = await tokenResponse.text();
+              throw new Error('Token fetch failed: ' + tokenText);
+            }
+            var tokenData = await tokenResponse.json();
+            var token = tokenData && tokenData.token;
+            if (!token) {
+              throw new Error('Token response missing token');
+            }
+            user = {
+              token: token,
+              provider: 'github',
+              backendName: 'github',
+              useOpenAuthoring: false,
+            };
+            persistUser(user);
+          }
+
+          backend.token = user.token;
+        }
+
+        await ensureToken(config);
 
         function ready() {
           return new Promise(function (resolve) {

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -3,71 +3,127 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Private CMS</title>
-  <script>window.CMS_MANUAL_INIT = true;</script>
+  <title>Palestine CMS</title>
+  <script>
+    window.CMS_MANUAL_INIT = true;
+    window.__DECAP_CMS_LOAD_CONFIG__ = false;
+  </script>
   <style>
-    body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,Noto Sans,sans-serif;background:#f4f5f7;margin:0;padding:40px}
-    #app{max-width:960px;margin:0 auto}
-    .card{background:#1f2937;color:#e5e7eb;padding:16px 20px;border-radius:10px;box-shadow:0 6px 20px rgba(0,0,0,.08);display:inline-block}
-    .err{white-space:pre-wrap;background:#fff;color:#b91c1c;border:1px solid #fecaca;padding:12px;border-radius:8px;margin-top:16px}
+    body {
+      font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif;
+      background: #f4f5f7;
+      margin: 0;
+      padding: 40px;
+    }
+    #app {
+      max-width: 960px;
+      margin: 0 auto;
+    }
+    .card {
+      background: #1f2937;
+      color: #e5e7eb;
+      padding: 16px 20px;
+      border-radius: 10px;
+      box-shadow: 0 6px 20px rgba(0, 0, 0, 0.08);
+      display: inline-block;
+    }
+    .err {
+      white-space: pre-wrap;
+      background: #fff;
+      color: #b91c1c;
+      border: 1px solid #fecaca;
+      padding: 12px;
+      border-radius: 8px;
+      margin-top: 16px;
+    }
+    button.logout {
+      margin-top: 24px;
+      padding: 8px 16px;
+      border-radius: 6px;
+      border: none;
+      background: #ef4444;
+      color: #fff;
+      font-weight: 600;
+      cursor: pointer;
+    }
   </style>
 </head>
 <body>
-  <div id="app"><div class="card">PRIVATE CMS — Authenticated. Loading collections…</div></div>
+  <div id="app">
+    <div class="card">Private CMS — authenticated. Loading collections…</div>
+    <button class="logout" type="button" style="display:none">Clear saved token</button>
+  </div>
 
   <script src="https://cdn.jsdelivr.net/npm/decap-cms@^3.8.4/dist/decap-cms.js"></script>
   <script>
-  (function installAuthMessageHandler(){
-    // Accept the token from the OAuth popup and persist in the shape Decap expects.
-    window.addEventListener('message', function(e){
-      var d = e && e.data;
-      if (!d || typeof d !== 'object') return;
-      if (!d.token) return;
+    (function installAuthMessageHandler() {
+      window.addEventListener('message', function (event) {
+        var payload = event && event.data;
+        if (!payload || typeof payload !== 'object') return;
+        if (!payload.token) return;
+        if (payload.provider !== 'github' || payload.backendName !== 'github') return;
 
-      // Decap/Netlify CMS historically looks for these keys
-      var payload = {
-        token: d.token,
-        provider: 'github',
-        backendName: 'github',
-        useOpenAuthoring: false
-      };
+        try {
+          var serialized = JSON.stringify(payload);
+          localStorage.setItem('decap-cms-user', serialized);
+          localStorage.setItem('netlify-cms-user', serialized);
+        } catch (_) {}
 
+        location.replace(location.href.split('#')[0]);
+      });
+    })();
+
+    (function installLogoutHandler() {
+      var button = document.querySelector('button.logout');
+      if (!button) return;
       try {
-        var s = JSON.stringify(payload);
-        localStorage.setItem('decap-cms-user', s);     // current
-        localStorage.setItem('netlify-cms-user', s);   // legacy
+        var stored = localStorage.getItem('decap-cms-user') || localStorage.getItem('netlify-cms-user');
+        if (stored) {
+          button.style.display = 'inline-block';
+        }
       } catch (_) {}
+      button.addEventListener('click', function () {
+        try {
+          localStorage.removeItem('decap-cms-user');
+          localStorage.removeItem('netlify-cms-user');
+        } catch (_) {}
+        location.replace(location.href.split('#')[0]);
+      });
+    })();
 
-      // Hard reload so the app reboots into the authenticated editor
-      location.replace(location.href.split('#')[0]);
-    });
-  })();
+    (async function boot() {
+      var app = document.getElementById('app');
+      try {
+        var res = await fetch('/api/cms/config', {
+          cache: 'no-store',
+          headers: { accept: 'application/json' },
+        });
+        if (!res.ok) {
+          var txt = await res.text();
+          app.innerHTML = '<div class="err">Config load failed:<br>' + txt + '</div>';
+          return;
+        }
+        var config = await res.json();
+        window.CMS_CONFIG = config;
 
-  (async function boot(){
-    try{
-      // Pull JSON config from our API (no config.yml fetch)
-      const res = await fetch('/api/cms/config', { cache: 'no-store', headers: { accept: 'application/json' }});
-      if (!res.ok) {
-        const txt = await res.text();
-        document.getElementById('app').innerHTML =
-          '<div class="err">Config load failed:<br>'+txt+'</div>';
-        return;
+        function ready() {
+          return new Promise(function (resolve) {
+            (function wait() {
+              if (window.CMS && typeof CMS.init === 'function') {
+                return resolve();
+              }
+              setTimeout(wait, 10);
+            })();
+          });
+        }
+
+        await ready();
+        CMS.init({ config: config, load_config_file: false });
+      } catch (error) {
+        var message = error && error.message ? error.message : error;
+        app.innerHTML = '<div class="err">Admin boot error:<br>' + message + '</div>';
       }
-      const cfg = await res.json();
-
-      // Provide config to Decap explicitly; do not load a file
-      window.CMS_CONFIG = cfg;
-      window.__DECAP_CMS_LOAD_CONFIG__ = false;
-
-      // If a token is already present (prior login), Decap should boot directly into the UI
-      function ready(){return new Promise(r => (function t(){(window.CMS&&CMS.init)?r():setTimeout(t,10)})());}
-      await ready();
-      CMS.init({ config: cfg, load_config_file: false });
-    }catch(e){
-      document.getElementById('app').innerHTML =
-        '<div class="err">Admin boot error:<br>'+(e && e.message ? e.message : e)+'</div>';
-    }
-  })();
+    })();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- manual-init the Decap admin shell so it only pulls `/api/cms/config`, persists OAuth tokens, and ships a logout affordance
- harden the CMS config/OAuth/debug API routes to support both `oauth` and `token` modes on the Node runtime and never leak secrets
- require valid basic-auth + CMS mode in middleware and document the full private-CMS setup in the README

## Testing
- npm run test:unit

## Screenshots
- /admin after login (collections visible) – unable to capture in this sandbox without a valid GitHub OAuth/PAT credential
- Network panel (no config.yml) – unable to capture in this sandbox without the production GitHub credential
- /api/cms/debug-env JSON booleans – unavailable here because the sandbox lacks the production secret set


------
https://chatgpt.com/codex/tasks/task_b_690960b577a88320ac41842c27dd319f