### PR TITLE
feat: build custom admin cms

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,21 +1,12 @@
-# Basic authentication for /admin and /api/cms
-BASIC_AUTH_USER=
-BASIC_AUTH_PASS=
-
-# CMS backend mode
-CMS_MODE=token
-
-# GitHub token mode
-CMS_GITHUB_TOKEN=
-
-# GitHub OAuth mode
+CMS_AUTH_MODE=oauth
+CMS_GITHUB_REPO=jp-dunlap/Palestine
+CMS_GITHUB_BRANCH=main
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
-CMS_ALLOWED_USERS=joshua@example.org
-
-# Optional overrides
-CMS_GITHUB_REPO=
-CMS_GITHUB_BRANCH=
-
-# External services
-LIBRETRANSLATE_URL=
+NEXTAUTH_SECRET=
+NEXTAUTH_URL=
+CMS_GITHUB_TOKEN=
+BASIC_AUTH_USER=
+BASIC_AUTH_PASS=
+ALLOWED_EMAILS=joshuaphilipdunlap@gmail.com
+ALLOWED_GITHUB_LOGINS=jp-dunlap

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,0 +1,504 @@
+'use client'
+
+import { useEffect, useMemo, useRef, useState } from 'react'
+import CollectionSwitcher, { type CollectionSummary } from '@/components/CollectionSwitcher'
+import EntryList, { type Entry } from '@/components/EntryList'
+import Editor, { type EditorState, type JsonEditorState, type MarkdownEditorState } from '@/components/Editor'
+
+type Session = {
+  name?: string
+  email?: string
+  login?: string
+}
+
+type Toast = {
+  id: number
+  type: 'success' | 'error'
+  message: string
+}
+
+const fetchJSON = async <T,>(url: string, init?: RequestInit): Promise<T> => {
+  const response = await fetch(url, init)
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ error: 'Request failed' }))
+    throw new Error(error.error ?? 'Request failed')
+  }
+  return response.json() as Promise<T>
+}
+
+const AdminPage = () => {
+  const [authMode, setAuthMode] = useState<'oauth' | 'token' | null>(null)
+  const [requiresLogin, setRequiresLogin] = useState(false)
+  const [session, setSession] = useState<Session | null>(null)
+  const [csrfToken, setCsrfToken] = useState<string | null>(null)
+  const [collections, setCollections] = useState<CollectionSummary[]>([])
+  const [selectedCollection, setSelectedCollection] = useState<string | null>(null)
+  const [entries, setEntries] = useState<Entry[]>([])
+  const [search, setSearch] = useState('')
+  const [selectedSlug, setSelectedSlug] = useState<string | null>(null)
+  const [editorState, setEditorState] = useState<EditorState | null>(null)
+  const [workflow, setWorkflow] = useState<'draft' | 'publish'>('publish')
+  const [message, setMessage] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [loadingEntries, setLoadingEntries] = useState(false)
+  const [unsaved, setUnsaved] = useState(false)
+  const [isNew, setIsNew] = useState(false)
+  const [toasts, setToasts] = useState<Toast[]>([])
+  const slugRef = useRef<string | null>(null)
+
+  const pushToast = (type: 'success' | 'error', messageText: string) => {
+    const id = Date.now()
+    setToasts((current) => [...current, { id, type, message: messageText }])
+    setTimeout(() => {
+      setToasts((current) => current.filter((toast) => toast.id !== id))
+    }, 4000)
+  }
+
+  useEffect(() => {
+    const loadSession = async () => {
+      try {
+        const response = await fetch('/api/admin/me')
+        if (response.status === 401) {
+          setAuthMode('oauth')
+          setRequiresLogin(true)
+          setSession(null)
+          setCsrfToken(null)
+          return
+        }
+        if (!response.ok) {
+          throw new Error('Unable to load session')
+        }
+        const data = await response.json()
+        if (data.mode === 'token') {
+          setAuthMode('token')
+          setSession(null)
+          setCsrfToken(typeof data.csrfToken === 'string' ? data.csrfToken : null)
+          setRequiresLogin(false)
+        } else {
+          setAuthMode('oauth')
+          setSession(data)
+          setCsrfToken(null)
+          setRequiresLogin(false)
+        }
+      } catch (error) {
+        pushToast('error', (error as Error).message)
+        setCsrfToken(null)
+      }
+    }
+    loadSession()
+  }, [])
+
+  useEffect(() => {
+    if (!authMode || requiresLogin) {
+      return
+    }
+    const loadCollections = async () => {
+      try {
+        const data = await fetchJSON<CollectionSummary[]>('/api/admin/collections')
+        setCollections(data)
+        if (data.length > 0) {
+          setSelectedCollection(data[0].id)
+          setWorkflow(data[0].defaultWorkflow)
+        }
+      } catch (error) {
+        pushToast('error', (error as Error).message)
+      }
+    }
+    loadCollections()
+  }, [authMode, requiresLogin])
+
+  const loadEntries = async (collectionId: string) => {
+    setLoadingEntries(true)
+    try {
+      const data = await fetchJSON<Entry[]>(`/api/admin/list?collection=${encodeURIComponent(collectionId)}`)
+      setEntries(data)
+    } catch (error) {
+      pushToast('error', (error as Error).message)
+      setEntries([])
+    } finally {
+      setLoadingEntries(false)
+    }
+  }
+
+  useEffect(() => {
+    if (!selectedCollection) {
+      return
+    }
+    loadEntries(selectedCollection)
+  }, [selectedCollection])
+
+  const fetchEntry = async (slug: string, desiredWorkflow: 'draft' | 'publish') => {
+    if (!selectedCollection) {
+      return
+    }
+    try {
+      const query = new URLSearchParams({
+        collection: selectedCollection,
+        slug,
+        workflow: desiredWorkflow,
+      })
+      const data = await fetchJSON<{
+        frontmatter?: Record<string, unknown>
+        body?: string
+        data?: Record<string, unknown>
+      }>(`/api/admin/item?${query.toString()}`)
+      const collection = collections.find((item) => item.id === selectedCollection)
+      if (collection?.format === 'json') {
+        const jsonState: JsonEditorState = {
+          format: 'json',
+          json: JSON.stringify(data.data ?? data.frontmatter ?? {}, null, 2),
+        }
+        setEditorState(jsonState)
+      } else {
+        const mdState: MarkdownEditorState = {
+          format: 'markdown',
+          frontmatter: data.frontmatter ?? {},
+          body: data.body ?? '',
+        }
+        setEditorState(mdState)
+      }
+      setUnsaved(false)
+      setIsNew(false)
+      slugRef.current = slug
+    } catch (error) {
+      pushToast('error', (error as Error).message)
+    }
+  }
+
+  const handleSelectEntry = (slug: string) => {
+    if (unsaved && !window.confirm('Discard unsaved changes?')) {
+      return
+    }
+    setSelectedSlug(slug)
+    setWorkflow('publish')
+    setMessage('')
+    fetchEntry(slug, 'publish')
+  }
+
+  const handleCreate = () => {
+    if (unsaved && !window.confirm('Discard unsaved changes?')) {
+      return
+    }
+    const collection = collections.find((item) => item.id === selectedCollection)
+    if (!collection) {
+      return
+    }
+    setSelectedSlug(null)
+    setIsNew(true)
+    setWorkflow(collection.defaultWorkflow)
+    setMessage('')
+    slugRef.current = null
+    if (collection.format === 'json') {
+      setEditorState({
+        format: 'json',
+        json: JSON.stringify({ slug: '', title: '' }, null, 2),
+      })
+    } else {
+      setEditorState({
+        format: 'markdown',
+        frontmatter: { title: '', [collection.slugField]: '' },
+        body: '',
+      })
+    }
+    setUnsaved(false)
+  }
+
+  const filteredEntries = useMemo(() => {
+    if (!search) {
+      return entries
+    }
+    const query = search.toLowerCase()
+    return entries.filter((entry) =>
+      entry.title.toLowerCase().includes(query) || entry.slug.toLowerCase().includes(query),
+    )
+  }, [entries, search])
+
+  useEffect(() => {
+    const handler = (event: BeforeUnloadEvent) => {
+      if (unsaved) {
+        event.preventDefault()
+        event.returnValue = ''
+      }
+    }
+    window.addEventListener('beforeunload', handler)
+    return () => window.removeEventListener('beforeunload', handler)
+  }, [unsaved])
+
+  const handleChangeState = (value: EditorState) => {
+    setEditorState(value)
+    setUnsaved(true)
+  }
+
+  const handleWorkflowChange = (nextWorkflow: 'draft' | 'publish') => {
+    if (unsaved && !window.confirm('Changing workflow will discard unsaved changes. Continue?')) {
+      return
+    }
+    setWorkflow(nextWorkflow)
+    setMessage('')
+    if (selectedSlug && !isNew) {
+      fetchEntry(selectedSlug, nextWorkflow)
+    }
+  }
+
+  const resolveSlug = (state: EditorState, collection: CollectionSummary) => {
+    if (state.format === 'markdown') {
+      const value = state.frontmatter[collection.slugField]
+      if (typeof value === 'string' && value) {
+        return value
+      }
+      const title = state.frontmatter.title
+      return typeof title === 'string' ? title : ''
+    }
+    try {
+      const parsed = JSON.parse(state.json)
+      const value = parsed?.[collection.slugField]
+      if (typeof value === 'string') {
+        return value
+      }
+      const title = parsed?.title
+      return typeof title === 'string' ? title : ''
+    } catch {
+      return ''
+    }
+  }
+
+  const handleSave = async () => {
+    if (!selectedCollection || !editorState) {
+      return
+    }
+    const collection = collections.find((item) => item.id === selectedCollection)
+    if (!collection) {
+      return
+    }
+    let frontmatter: Record<string, unknown> | undefined
+    let body: string | undefined
+    let data: Record<string, unknown> | undefined
+    if (editorState.format === 'markdown') {
+      frontmatter = editorState.frontmatter
+      body = editorState.body
+    } else {
+      try {
+        data = JSON.parse(editorState.json)
+      } catch {
+        pushToast('error', 'Invalid JSON payload')
+        return
+      }
+    }
+    const slugValue = resolveSlug(editorState, collection)
+    setSaving(true)
+    try {
+      const payload: Record<string, unknown> = {
+        collection: selectedCollection,
+        slug: slugValue,
+        workflow,
+        message: message.trim(),
+      }
+      if (frontmatter) payload.frontmatter = frontmatter
+      if (body !== undefined) payload.body = body
+      if (data) payload.data = data
+      const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+      if (csrfToken) {
+        headers['x-csrf-token'] = csrfToken
+      }
+      const response = await fetch('/api/admin/save', {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(payload),
+      })
+      if (!response.ok) {
+        const error = await response.json().catch(() => ({ error: 'Unable to save entry' }))
+        throw new Error(error.error ?? 'Unable to save entry')
+      }
+      const json = await response.json()
+      if (json.prUrl) {
+        pushToast('success', `Draft updated: ${json.prUrl}`)
+      } else {
+        pushToast('success', 'Entry saved to main branch')
+      }
+      const nextSlug = slugValue || slugRef.current
+      if (nextSlug) {
+        setSelectedSlug(nextSlug)
+        slugRef.current = nextSlug
+      }
+      setMessage('')
+      setUnsaved(false)
+      setIsNew(false)
+      await loadEntries(selectedCollection)
+      if (nextSlug) {
+        await fetchEntry(nextSlug, workflow)
+      }
+    } catch (error) {
+      pushToast('error', (error as Error).message)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleDelete = async () => {
+    if (!selectedCollection) {
+      return
+    }
+    const slug = selectedSlug ?? slugRef.current
+    if (!slug) {
+      pushToast('error', 'No entry selected')
+      return
+    }
+    if (!window.confirm('Delete this entry? This cannot be undone.')) {
+      return
+    }
+    try {
+      const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+      if (csrfToken) {
+        headers['x-csrf-token'] = csrfToken
+      }
+      const response = await fetch('/api/admin/item', {
+        method: 'DELETE',
+        headers,
+        body: JSON.stringify({
+          collection: selectedCollection,
+          slug,
+          workflow,
+          message: message.trim(),
+        }),
+      })
+      if (!response.ok) {
+        const error = await response.json().catch(() => ({ error: 'Unable to delete entry' }))
+        throw new Error(error.error ?? 'Unable to delete entry')
+      }
+      const json = await response.json().catch(() => ({}))
+      if (json.prUrl) {
+        pushToast('success', `Deletion draft ready: ${json.prUrl}`)
+      } else {
+        pushToast('success', 'Entry removed')
+      }
+      setEditorState(null)
+      setSelectedSlug(null)
+      setUnsaved(false)
+      setMessage('')
+      slugRef.current = null
+      await loadEntries(selectedCollection)
+    } catch (error) {
+      pushToast('error', (error as Error).message)
+    }
+  }
+
+  const handleSignOut = async () => {
+    try {
+      await fetch('/api/auth/signout', { method: 'POST' })
+    } finally {
+      window.location.reload()
+    }
+  }
+
+  const collection = collections.find((item) => item.id === selectedCollection) ?? null
+
+  return (
+    <div className="flex min-h-screen flex-col bg-zinc-100">
+      <header className="border-b border-zinc-200 bg-white">
+        <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
+          <div>
+            <h1 className="text-lg font-semibold text-zinc-900">Palestine CMS Admin</h1>
+            {session ? (
+              <p className="text-xs text-zinc-500">
+                Signed in as {session.name ?? session.login}
+              </p>
+            ) : authMode === 'token' ? (
+              <p className="text-xs text-zinc-500">Token mode</p>
+            ) : null}
+          </div>
+          <div className="flex items-center gap-3 text-sm">
+            {authMode === 'oauth' && !requiresLogin ? (
+              <button
+                type="button"
+                onClick={handleSignOut}
+                className="rounded border border-zinc-300 px-3 py-1.5 text-sm text-zinc-700 transition hover:border-black hover:text-black"
+              >
+                Sign out
+              </button>
+            ) : null}
+            {authMode === 'oauth' && requiresLogin ? (
+              <a
+                href="/api/auth/signin"
+                className="rounded border border-black px-3 py-1.5 text-sm font-medium text-black transition hover:bg-black hover:text-white"
+              >
+                Sign in with GitHub
+              </a>
+            ) : null}
+          </div>
+        </div>
+      </header>
+
+      <main className="mx-auto flex w-full max-w-6xl flex-1 gap-6 px-6 py-6">
+        <aside className="w-56">
+          <CollectionSwitcher
+            collections={collections}
+            selected={selectedCollection}
+            onSelect={(id) => {
+              if (unsaved && !window.confirm('Discard unsaved changes?')) {
+                return
+              }
+              setSelectedCollection(id)
+              const next = collections.find((item) => item.id === id)
+              setWorkflow(next?.defaultWorkflow ?? 'publish')
+              setSelectedSlug(null)
+              setEditorState(null)
+              setSearch('')
+              setUnsaved(false)
+              setIsNew(false)
+            }}
+          />
+        </aside>
+        <section className="flex w-72 flex-col">
+          {loadingEntries ? (
+            <div className="flex flex-1 items-center justify-center text-sm text-zinc-500">Loading entries…</div>
+          ) : (
+            <EntryList
+              entries={filteredEntries}
+              selected={selectedSlug}
+              onSelect={handleSelectEntry}
+              onCreate={handleCreate}
+              search={search}
+              onSearch={setSearch}
+            />
+          )}
+        </section>
+        <section className="flex flex-1 flex-col">
+          <div className="flex-1 rounded border border-zinc-200 bg-white p-6 shadow-sm">
+            <Editor
+              collection={collection}
+              state={editorState}
+              onChange={handleChangeState}
+              onSave={handleSave}
+              onDelete={handleDelete}
+              saving={saving}
+              unsaved={unsaved}
+              workflow={workflow}
+              onWorkflowChange={handleWorkflowChange}
+              message={message}
+              onMessageChange={setMessage}
+              onError={(text) => pushToast('error', text)}
+              csrfToken={csrfToken}
+            />
+          </div>
+        </section>
+      </main>
+
+      <div className="fixed right-6 top-6 flex flex-col gap-2">
+        {toasts.map((toast) => (
+          <div
+            key={toast.id}
+            className={`min-w-[220px] rounded border px-4 py-2 text-sm shadow ${
+              toast.type === 'success'
+                ? 'border-green-500 bg-green-50 text-green-700'
+                : 'border-red-500 bg-red-50 text-red-700'
+            }`}
+          >
+            {toast.message}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export default AdminPage

--- a/app/api/admin/collections/route.ts
+++ b/app/api/admin/collections/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { ensureAuth } from '@/lib/api/auth'
+import { collections } from '@/lib/collections'
+
+export const GET = async (req: NextRequest) => {
+  const auth = ensureAuth(req)
+  if (!auth.ok) {
+    return auth.response
+  }
+  const payload = collections.map((collection) => ({
+    id: collection.id,
+    label: collection.label,
+    format: collection.format,
+    defaultWorkflow: collection.defaultWorkflow,
+    slugField: collection.slugField,
+    fields: collection.fields,
+  }))
+  return NextResponse.json(payload)
+}

--- a/app/api/admin/item/route.ts
+++ b/app/api/admin/item/route.ts
@@ -1,0 +1,123 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { ensureAuth } from '@/lib/api/auth'
+import { requireCsrfToken } from '@/lib/api/csrf'
+import { getCollection, getEntryPath } from '@/lib/collections'
+import { readEntry } from '@/lib/content'
+import {
+  createPullRequest,
+  deleteFile,
+  ensureBranch,
+  findPullRequestByBranch,
+  getFile,
+  getOctokitForRequest,
+  resolveCommitAuthor,
+  updatePullRequestBody,
+} from '@/lib/github'
+import { rateLimit } from '@/lib/rate-limit'
+
+export const GET = async (req: NextRequest) => {
+  const auth = ensureAuth(req)
+  if (!auth.ok) {
+    return auth.response
+  }
+  const url = new URL(req.url)
+  const collectionId = url.searchParams.get('collection')
+  const slug = url.searchParams.get('slug')
+  const workflow = url.searchParams.get('workflow') ?? 'publish'
+  if (!collectionId || !slug) {
+    return NextResponse.json({ error: 'collection and slug are required' }, { status: 400 })
+  }
+  const collection = getCollection(collectionId)
+  if (!collection) {
+    return NextResponse.json({ error: 'Collection not found' }, { status: 404 })
+  }
+  try {
+    const branch = workflow === 'draft' ? `cms/${slug}` : undefined
+    const client = getOctokitForRequest(req)
+    const entry = await readEntry(client, collection, slug, branch)
+    return NextResponse.json({
+      frontmatter: entry.frontmatter,
+      body: entry.body,
+      data: entry.data,
+      sha: entry.sha,
+      path: entry.path,
+      workflow,
+    })
+  } catch (error) {
+    const message = (error as Error).message
+    const status = message === 'Not Found' ? 404 : 500
+    return NextResponse.json({ error: message }, { status })
+  }
+}
+
+const ipKey = (req: NextRequest) => {
+  const forwarded = req.headers.get('x-forwarded-for')
+  if (forwarded) {
+    return forwarded.split(',')[0]
+  }
+  return req.ip ?? 'unknown'
+}
+
+export const DELETE = async (req: NextRequest) => {
+  const auth = ensureAuth(req)
+  if (!auth.ok) {
+    return auth.response
+  }
+  if (auth.mode === 'token') {
+    const csrf = requireCsrfToken(req)
+    if (csrf) {
+      return csrf
+    }
+  }
+  const limited = rateLimit(`delete:${ipKey(req)}`, 5, 60_000)
+  if (!limited.success) {
+    return NextResponse.json({ error: 'Rate limit exceeded' }, { status: 429 })
+  }
+  let payload: any
+  try {
+    payload = await req.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+  const { collection: collectionId, slug, workflow, message } = payload ?? {}
+  if (typeof collectionId !== 'string' || typeof slug !== 'string') {
+    return NextResponse.json({ error: 'collection and slug are required' }, { status: 400 })
+  }
+  const collection = getCollection(collectionId)
+  if (!collection) {
+    return NextResponse.json({ error: 'Collection not found' }, { status: 404 })
+  }
+  const branchWorkflow: 'draft' | 'publish' = workflow === 'draft' ? 'draft' : 'publish'
+  const branchName = branchWorkflow === 'draft' ? `cms/${slug}` : undefined
+  const client = getOctokitForRequest(req)
+  const author = resolveCommitAuthor(auth.mode === 'oauth' ? auth.session : undefined)
+  const path = getEntryPath(collection, slug)
+  try {
+    if (branchName) {
+      await ensureBranch(client, branchName)
+    }
+    const existing = await getFile(client, path, branchName).catch(() => null)
+    if (!existing) {
+      return NextResponse.json({ error: 'Entry not found' }, { status: 404 })
+    }
+    const commitMessage = typeof message === 'string' && message.trim().length > 0
+      ? message
+      : `[CMS] Delete ${collection.label}: ${slug}`
+    const response = await deleteFile(client, path, commitMessage, branchName, existing.sha, author)
+    if (branchWorkflow === 'draft' && branchName) {
+      const existingPr = await findPullRequestByBranch(client, branchName)
+      const prTitle = `[CMS] ${slug}`
+      const prBody = `This PR removes ${slug} from ${collection.label}.`
+      if (existingPr) {
+        await updatePullRequestBody(client, existingPr.number, prBody)
+        return NextResponse.json({ prUrl: existingPr.html_url, workflow: 'draft' })
+      }
+      const pr = await createPullRequest(client, branchName, prTitle, prBody)
+      return NextResponse.json({ prUrl: pr.html_url, workflow: 'draft' })
+    }
+    const commitSha = (response as any)?.commit?.sha ?? null
+    return NextResponse.json({ commitSha, workflow: 'publish' })
+  } catch (error) {
+    return NextResponse.json({ error: (error as Error).message }, { status: 500 })
+  }
+}

--- a/app/api/admin/list/route.ts
+++ b/app/api/admin/list/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { ensureAuth } from '@/lib/api/auth'
+import { getCollection } from '@/lib/collections'
+import { listEntries } from '@/lib/content'
+import { getOctokitForRequest } from '@/lib/octokit'
+
+export const GET = async (req: NextRequest) => {
+  const auth = ensureAuth(req)
+  if (!auth.ok) {
+    return auth.response
+  }
+  const url = new URL(req.url)
+  const collectionId = url.searchParams.get('collection')
+  if (!collectionId) {
+    return NextResponse.json({ error: 'collection is required' }, { status: 400 })
+  }
+  const collection = getCollection(collectionId)
+  if (!collection) {
+    return NextResponse.json({ error: 'Collection not found' }, { status: 404 })
+  }
+  try {
+    const client = getOctokitForRequest(req)
+    const entries = await listEntries(client, collection)
+    return NextResponse.json(entries)
+  } catch (error) {
+    return NextResponse.json({ error: (error as Error).message }, { status: 500 })
+  }
+}

--- a/app/api/admin/me/route.ts
+++ b/app/api/admin/me/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { ensureAuth } from '@/lib/api/auth'
+import { createCsrfToken, readCsrfToken, setCsrfCookie } from '@/lib/api/csrf'
+
+export const GET = async (req: NextRequest) => {
+  const auth = ensureAuth(req)
+  if (!auth.ok) {
+    return auth.response
+  }
+  if (auth.mode === 'token') {
+    const existing = readCsrfToken(req)
+    const token = existing ?? createCsrfToken()
+    const response = NextResponse.json({ mode: 'token', csrfToken: token })
+    setCsrfCookie(response, token)
+    return response
+  }
+  const { name, email, login } = auth.session
+  return NextResponse.json({ name, email, login })
+}

--- a/app/api/admin/save/route.ts
+++ b/app/api/admin/save/route.ts
@@ -124,7 +124,7 @@ export const POST = async (req: NextRequest) => {
 
   const commitMessage = typeof message === 'string' && message.trim().length > 0
     ? message
-    : `[CMS] ${branchWorkflow === 'draft' ? 'Draft' : 'Publish'} ${collection.label}: ${slug}`
+    : `[CMS] ${branchWorkflow.charAt(0).toUpperCase()}${branchWorkflow.slice(1)} ${collection.label}: ${slug}`
 
   try {
     const response = await putFile(

--- a/app/api/admin/save/route.ts
+++ b/app/api/admin/save/route.ts
@@ -1,0 +1,158 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { ensureAuth } from '@/lib/api/auth'
+import { requireCsrfToken } from '@/lib/api/csrf'
+import { getCollection, getEntryPath } from '@/lib/collections'
+import { serializeEntry } from '@/lib/content'
+import {
+  createPullRequest,
+  ensureBranch,
+  findPullRequestByBranch,
+  getFile,
+  getOctokitForRequest,
+  getRawFileUrl,
+  putFile,
+  resolveCommitAuthor,
+  updatePullRequestBody,
+} from '@/lib/github'
+import { rateLimit } from '@/lib/rate-limit'
+import { slugify } from '@/lib/slugs'
+
+const parseBody = async (req: NextRequest) => {
+  try {
+    return await req.json()
+  } catch {
+    return null
+  }
+}
+
+const toSlug = (value?: string | null) => {
+  if (!value) return ''
+  return slugify(value)
+}
+
+const rateLimitKey = (req: NextRequest) => {
+  const forwarded = req.headers.get('x-forwarded-for')
+  if (forwarded) {
+    return forwarded.split(',')[0]
+  }
+  return req.ip ?? 'unknown'
+}
+
+const buildPrBody = (collectionLabel: string, slug: string, summary: Record<string, unknown>) => {
+  const lines = Object.entries(summary)
+    .filter(([key]) => key !== 'body')
+    .map(([key, value]) => `- **${key}**: ${Array.isArray(value) ? value.join(', ') : String(value ?? '')}`)
+  return [`This PR was created from the Palestine CMS admin for ${collectionLabel}.`, '', `Slug: \`${slug}\``, '', ...lines].join('\n')
+}
+
+export const POST = async (req: NextRequest) => {
+  const auth = ensureAuth(req)
+  if (!auth.ok) {
+    return auth.response
+  }
+  if (auth.mode === 'token') {
+    const csrf = requireCsrfToken(req)
+    if (csrf) {
+      return csrf
+    }
+  }
+  const limited = rateLimit(`save:${rateLimitKey(req)}`, 10, 60_000)
+  if (!limited.success) {
+    return NextResponse.json({ error: 'Rate limit exceeded' }, { status: 429 })
+  }
+  const body = await parseBody(req)
+  if (!body) {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+  const { collection: collectionId, slug: inputSlug, frontmatter = {}, data, body: markdownBody, workflow, message } = body
+  if (typeof collectionId !== 'string') {
+    return NextResponse.json({ error: 'collection is required' }, { status: 400 })
+  }
+  const collection = getCollection(collectionId)
+  if (!collection) {
+    return NextResponse.json({ error: 'Collection not found' }, { status: 404 })
+  }
+  const candidateData = collection.format === 'markdown' ? (frontmatter as Record<string, unknown>) : (data ?? frontmatter)
+  if (!candidateData || typeof candidateData !== 'object') {
+    return NextResponse.json({ error: 'frontmatter/data must be an object' }, { status: 400 })
+  }
+  const parsed = collection.schema.safeParse(candidateData)
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Validation failed', issues: parsed.error.issues }, { status: 422 })
+  }
+  const validated = parsed.data as Record<string, unknown>
+  let slug = typeof inputSlug === 'string' && inputSlug.length > 0 ? toSlug(inputSlug) : ''
+  if (!slug) {
+    const slugSource = validated[collection.slugField]
+    if (typeof slugSource === 'string' && slugSource) {
+      slug = toSlug(slugSource)
+    }
+  }
+  if (!slug) {
+    const title = validated.title
+    if (typeof title === 'string') {
+      slug = toSlug(title)
+    }
+  }
+  if (!slug) {
+    return NextResponse.json({ error: 'Unable to determine slug' }, { status: 400 })
+  }
+  validated[collection.slugField] = slug
+
+  const branchWorkflow: 'draft' | 'publish' = workflow === 'draft' ? 'draft' : workflow === 'publish' ? 'publish' : collection.defaultWorkflow
+  const branchName = branchWorkflow === 'draft' ? `cms/${slug}` : undefined
+
+  const payload = collection.format === 'markdown'
+    ? { frontmatter: validated, body: typeof markdownBody === 'string' ? markdownBody : '' }
+    : { frontmatter: validated, data: validated }
+
+  const content = serializeEntry(collection, payload)
+
+  const client = getOctokitForRequest(req)
+  const path = getEntryPath(collection, slug)
+  const author = resolveCommitAuthor(auth.mode === 'oauth' ? auth.session : undefined)
+
+  try {
+    if (branchName) {
+      await ensureBranch(client, branchName)
+    }
+  } catch (error) {
+    return NextResponse.json({ error: (error as Error).message }, { status: 500 })
+  }
+
+  const existing = await getFile(client, path, branchName).catch(() => null)
+
+  const commitMessage = typeof message === 'string' && message.trim().length > 0
+    ? message
+    : `[CMS] ${branchWorkflow === 'draft' ? 'Draft' : 'Publish'} ${collection.label}: ${slug}`
+
+  try {
+    const response = await putFile(
+      client,
+      path,
+      content,
+      commitMessage,
+      branchName,
+      existing?.sha,
+      author,
+    )
+
+    if (branchWorkflow === 'draft' && branchName) {
+      const summary = { ...validated }
+      const existingPr = await findPullRequestByBranch(client, branchName)
+      const prTitle = `[CMS] ${slug}`
+      const prBody = buildPrBody(collection.label, slug, summary)
+      if (existingPr) {
+        await updatePullRequestBody(client, existingPr.number, prBody)
+        return NextResponse.json({ prUrl: existingPr.html_url, workflow: 'draft' })
+      }
+      const pr = await createPullRequest(client, branchName, prTitle, prBody)
+      return NextResponse.json({ prUrl: pr.html_url, workflow: 'draft' })
+    }
+
+    const commitSha = (response as any)?.commit?.sha ?? null
+    return NextResponse.json({ commitSha, urlToRaw: getRawFileUrl(path), workflow: 'publish' })
+  } catch (error) {
+    return NextResponse.json({ error: (error as Error).message }, { status: 500 })
+  }
+}

--- a/app/api/admin/upload/route.ts
+++ b/app/api/admin/upload/route.ts
@@ -1,0 +1,70 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { ensureAuth } from '@/lib/api/auth'
+import { requireCsrfToken } from '@/lib/api/csrf'
+import { getOctokitForRequest, putFile, resolveCommitAuthor } from '@/lib/github'
+import { rateLimit } from '@/lib/rate-limit'
+import { sanitizeFilename } from '@/lib/slugs'
+
+const ALLOWED_TYPES = new Set([
+  'image/png',
+  'image/jpeg',
+  'image/webp',
+  'image/gif',
+  'image/svg+xml',
+])
+
+const MAX_SIZE = 5 * 1024 * 1024
+
+const ipKey = (req: NextRequest) => {
+  const forwarded = req.headers.get('x-forwarded-for')
+  if (forwarded) {
+    return forwarded.split(',')[0]
+  }
+  return req.ip ?? 'unknown'
+}
+
+export const POST = async (req: NextRequest) => {
+  const auth = ensureAuth(req)
+  if (!auth.ok) {
+    return auth.response
+  }
+  if (auth.mode === 'token') {
+    const csrf = requireCsrfToken(req)
+    if (csrf) {
+      return csrf
+    }
+  }
+  const limited = rateLimit(`upload:${ipKey(req)}`, 5, 60_000)
+  if (!limited.success) {
+    return NextResponse.json({ error: 'Rate limit exceeded' }, { status: 429 })
+  }
+  const form = await req.formData().catch(() => null)
+  if (!form) {
+    return NextResponse.json({ error: 'Invalid form data' }, { status: 400 })
+  }
+  const file = form.get('file')
+  if (!file || typeof file === 'string') {
+    return NextResponse.json({ error: 'file is required' }, { status: 400 })
+  }
+  if (!ALLOWED_TYPES.has(file.type)) {
+    return NextResponse.json({ error: 'Unsupported file type' }, { status: 400 })
+  }
+  if (file.size > MAX_SIZE) {
+    return NextResponse.json({ error: 'File too large' }, { status: 400 })
+  }
+  const originalName = sanitizeFilename(file.name ?? 'upload')
+  const baseName = originalName.length > 0 ? originalName : 'upload'
+  const timestamp = Date.now()
+  const filename = `${timestamp}-${baseName}`
+  const storagePath = `public/images/uploads/${filename}`
+  const buffer = Buffer.from(await file.arrayBuffer())
+  const client = getOctokitForRequest(req)
+  const author = resolveCommitAuthor(auth.mode === 'oauth' ? auth.session : undefined)
+  const message = `[CMS] Upload image ${filename}`
+  try {
+    await putFile(client, storagePath, buffer, message, undefined, undefined, author)
+    return NextResponse.json({ url: `/images/uploads/${filename}` })
+  } catch (error) {
+    return NextResponse.json({ error: (error as Error).message }, { status: 500 })
+  }
+}

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,169 @@
+import { NextRequest, NextResponse } from 'next/server'
+import {
+  clearSessionCookie,
+  clearStateCookie,
+  createSession,
+  createStateToken,
+  getAuthMode,
+  getSessionFromRequest,
+  isAllowlisted,
+  readStateFromRequest,
+  setSessionCookie,
+  setStateCookie,
+} from '@/lib/auth'
+
+const githubTokenEndpoint = 'https://github.com/login/oauth/access_token'
+const githubUserEndpoint = 'https://api.github.com/user'
+const githubEmailsEndpoint = 'https://api.github.com/user/emails'
+
+const redirectUrl = () => {
+  const baseEnv = process.env.NEXTAUTH_URL ?? process.env.VERCEL_URL
+  if (!baseEnv) {
+    throw new Error('NEXTAUTH_URL must be configured')
+  }
+  const base = baseEnv.startsWith('http') ? baseEnv : `https://${baseEnv}`
+  return `${base.replace(/\/$/, '')}/api/auth/callback/github`
+}
+
+const getClientId = () => process.env.GITHUB_CLIENT_ID ?? ''
+const getClientSecret = () => process.env.GITHUB_CLIENT_SECRET ?? ''
+
+const ensureOAuthMode = () => {
+  if (getAuthMode() !== 'oauth') {
+    throw new Error('OAuth mode is disabled')
+  }
+  if (!getClientId() || !getClientSecret()) {
+    throw new Error('GitHub OAuth credentials are not configured')
+  }
+}
+
+const signIn = (req: NextRequest) => {
+  ensureOAuthMode()
+  const state = createStateToken()
+  const url = new URL('https://github.com/login/oauth/authorize')
+  url.searchParams.set('client_id', getClientId())
+  url.searchParams.set('redirect_uri', redirectUrl())
+  url.searchParams.set('scope', 'repo user')
+  url.searchParams.set('state', state)
+  const response = NextResponse.redirect(url.toString())
+  setStateCookie(response, state)
+  return response
+}
+
+const fetchAccessToken = async (code: string) => {
+  const response = await fetch(githubTokenEndpoint, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+    },
+    body: new URLSearchParams({
+      client_id: getClientId(),
+      client_secret: getClientSecret(),
+      code,
+      redirect_uri: redirectUrl(),
+    }),
+  })
+  if (!response.ok) {
+    throw new Error('Failed to exchange code for token')
+  }
+  const json = (await response.json()) as { access_token?: string; error?: string }
+  if (!json.access_token) {
+    throw new Error(json.error ?? 'Invalid OAuth response')
+  }
+  return json.access_token
+}
+
+const fetchUserProfile = async (token: string) => {
+  const headers = { Authorization: `Bearer ${token}`, 'User-Agent': 'palestine-cms-admin' }
+  const userResponse = await fetch(githubUserEndpoint, { headers })
+  if (!userResponse.ok) {
+    throw new Error('Failed to fetch user profile')
+  }
+  const profile = (await userResponse.json()) as { login: string; name?: string; email?: string | null }
+  if (!profile.email) {
+    const emailsResponse = await fetch(githubEmailsEndpoint, { headers })
+    if (emailsResponse.ok) {
+      const emails = (await emailsResponse.json()) as { email: string; primary?: boolean; verified?: boolean }[]
+      const primary = emails.find((entry) => entry.primary && entry.verified)
+      profile.email = primary?.email ?? emails[0]?.email ?? null
+    }
+  }
+  return profile
+}
+
+const oauthCallback = async (req: NextRequest) => {
+  ensureOAuthMode()
+  const url = new URL(req.url)
+  const code = url.searchParams.get('code')
+  const state = url.searchParams.get('state')
+  if (!code || !state) {
+    return NextResponse.json({ error: 'Invalid OAuth response' }, { status: 400 })
+  }
+  const storedState = readStateFromRequest(req)
+  if (!storedState || storedState !== state) {
+    return NextResponse.json({ error: 'Invalid state parameter' }, { status: 400 })
+  }
+  try {
+    const token = await fetchAccessToken(code)
+    const profile = await fetchUserProfile(token)
+    if (!isAllowlisted(profile)) {
+      return NextResponse.json({ error: 'Access denied' }, { status: 403 })
+    }
+    const response = NextResponse.redirect('/admin')
+    const sessionToken = createSession({
+      name: profile.name ?? profile.login,
+      email: profile.email ?? `${profile.login}@users.noreply.github.com`,
+      login: profile.login,
+      accessToken: token,
+    })
+    setSessionCookie(response, sessionToken)
+    clearStateCookie(response)
+    return response
+  } catch (error) {
+    return NextResponse.json({ error: (error as Error).message }, { status: 500 })
+  }
+}
+
+const getSession = (req: NextRequest) => {
+  const session = getSessionFromRequest(req)
+  if (!session) {
+    return NextResponse.json(null)
+  }
+  return NextResponse.json({ name: session.name, email: session.email, login: session.login })
+}
+
+const signOut = (req: NextRequest) => {
+  const response = NextResponse.json({ ok: true })
+  clearSessionCookie(response)
+  return response
+}
+
+const notFound = () => NextResponse.json({ error: 'Not Found' }, { status: 404 })
+
+export const GET = async (req: NextRequest) => {
+  const segments = req.nextUrl.pathname.split('/')
+  const action = segments.pop() ?? ''
+  if (action === 'signin') {
+    try {
+      return signIn(req)
+    } catch (error) {
+      return NextResponse.json({ error: (error as Error).message }, { status: 400 })
+    }
+  }
+  if (segments.pop() === 'callback') {
+    return oauthCallback(req)
+  }
+  if (action === 'session') {
+    return getSession(req)
+  }
+  return notFound()
+}
+
+export const POST = async (req: NextRequest) => {
+  const segments = req.nextUrl.pathname.split('/')
+  const action = segments.pop() ?? ''
+  if (action === 'signout') {
+    return signOut(req)
+  }
+  return notFound()
+}

--- a/components/CollectionSwitcher.tsx
+++ b/components/CollectionSwitcher.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+export type CollectionSummary = {
+  id: string
+  label: string
+  format: 'markdown' | 'json'
+  defaultWorkflow: 'draft' | 'publish'
+  slugField: string
+  fields: { name: string; type: string; required?: boolean }[]
+}
+
+type Props = {
+  collections: CollectionSummary[]
+  selected: string | null
+  onSelect: (id: string) => void
+}
+
+const CollectionSwitcher = ({ collections, selected, onSelect }: Props) => {
+  return (
+    <div className="flex flex-col gap-2">
+      {collections.map((collection) => (
+        <button
+          key={collection.id}
+          type="button"
+          onClick={() => onSelect(collection.id)}
+          className={`rounded border px-3 py-2 text-left text-sm transition ${
+            selected === collection.id
+              ? 'border-black bg-black text-white'
+              : 'border-zinc-300 bg-white text-zinc-900 hover:border-zinc-500'
+          }`}
+        >
+          <span className="block font-medium">{collection.label}</span>
+          <span className="block text-xs text-zinc-500">{collection.format.toUpperCase()}</span>
+        </button>
+      ))}
+    </div>
+  )
+}
+
+export default CollectionSwitcher

--- a/components/Editor.tsx
+++ b/components/Editor.tsx
@@ -1,0 +1,254 @@
+'use client'
+
+import { useEffect, useMemo } from 'react'
+import ImageUploader from './ImageUploader'
+import type { CollectionSummary } from './CollectionSwitcher'
+
+export type MarkdownEditorState = {
+  format: 'markdown'
+  frontmatter: Record<string, unknown>
+  body: string
+}
+
+export type JsonEditorState = {
+  format: 'json'
+  json: string
+}
+
+export type EditorState = MarkdownEditorState | JsonEditorState
+
+type Props = {
+  collection: CollectionSummary | null
+  state: EditorState | null
+  onChange: (state: EditorState) => void
+  onSave: () => void
+  onDelete: () => void
+  saving: boolean
+  unsaved: boolean
+  workflow: 'draft' | 'publish'
+  onWorkflowChange: (workflow: 'draft' | 'publish') => void
+  message: string
+  onMessageChange: (value: string) => void
+  onError: (message: string) => void
+  csrfToken: string | null
+}
+
+const fieldValue = (frontmatter: Record<string, unknown>, key: string) => {
+  const value = frontmatter[key]
+  return value === undefined ? '' : value
+}
+
+const Editor = ({
+  collection,
+  state,
+  onChange,
+  onSave,
+  onDelete,
+  saving,
+  unsaved,
+  workflow,
+  onWorkflowChange,
+  message,
+  onMessageChange,
+  onError,
+  csrfToken,
+}: Props) => {
+  useEffect(() => {
+    const handleKey = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 's') {
+        event.preventDefault()
+        onSave()
+      }
+    }
+    window.addEventListener('keydown', handleKey)
+    return () => window.removeEventListener('keydown', handleKey)
+  }, [onSave])
+
+  const frontmatterFields = useMemo(() => {
+    if (!collection) return []
+    return collection.fields.filter((field) => field.name !== 'body')
+  }, [collection])
+
+  if (!collection) {
+    return <div className="flex h-full items-center justify-center text-sm text-zinc-500">Select a collection.</div>
+  }
+
+  if (!state) {
+    return <div className="flex h-full items-center justify-center text-sm text-zinc-500">Select an entry to begin.</div>
+  }
+
+  const updateFrontmatter = (key: string, value: unknown) => {
+    if (state.format !== 'markdown') {
+      return
+    }
+    onChange({
+      ...state,
+      frontmatter: { ...state.frontmatter, [key]: value },
+    })
+  }
+
+  const renderField = (field: { name: string; type: string; required?: boolean }) => {
+    if (state.format !== 'markdown') {
+      return null
+    }
+    const value = fieldValue(state.frontmatter, field.name)
+    const label = field.name
+    if (field.type === 'string') {
+      return (
+        <label key={field.name} className="flex flex-col gap-1 text-sm">
+          <span className="font-medium text-zinc-700">
+            {label}
+            {field.required ? ' *' : ''}
+          </span>
+          <input
+            value={typeof value === 'string' ? value : ''}
+            onChange={(event) => updateFrontmatter(field.name, event.target.value)}
+            className="rounded border border-zinc-300 px-3 py-2 text-sm focus:border-black focus:outline-none"
+          />
+        </label>
+      )
+    }
+    if (field.type === 'string[]') {
+      const stringValue = Array.isArray(value) ? value.join(', ') : typeof value === 'string' ? value : ''
+      return (
+        <label key={field.name} className="flex flex-col gap-1 text-sm">
+          <span className="font-medium text-zinc-700">{label}</span>
+          <input
+            value={stringValue}
+            onChange={(event) => updateFrontmatter(field.name, event.target.value.split(',').map((entry) => entry.trim()).filter(Boolean))}
+            className="rounded border border-zinc-300 px-3 py-2 text-sm focus:border-black focus:outline-none"
+            placeholder="comma separated"
+          />
+        </label>
+      )
+    }
+    if (field.type === 'number[]') {
+      const stringValue = Array.isArray(value) ? value.join(', ') : typeof value === 'string' ? value : ''
+      return (
+        <label key={field.name} className="flex flex-col gap-1 text-sm">
+          <span className="font-medium text-zinc-700">{label}</span>
+          <input
+            value={stringValue}
+            onChange={(event) => {
+              const numbers = event
+                .target
+                .value
+                .split(',')
+                .map((entry) => entry.trim())
+                .filter((entry) => entry.length > 0)
+                .map((entry) => Number(entry))
+                .filter((num) => !Number.isNaN(num))
+              updateFrontmatter(field.name, numbers)
+            }}
+            className="rounded border border-zinc-300 px-3 py-2 text-sm focus:border-black focus:outline-none"
+            placeholder="comma separated"
+          />
+        </label>
+      )
+    }
+    if (field.type === 'boolean') {
+      return (
+        <label key={field.name} className="flex items-center gap-2 text-sm font-medium text-zinc-700">
+          <input
+            type="checkbox"
+            checked={Boolean(value)}
+            onChange={(event) => updateFrontmatter(field.name, event.target.checked)}
+          />
+          {label}
+        </label>
+      )
+    }
+    return null
+  }
+
+  return (
+    <div className="flex h-full flex-col gap-4">
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="flex items-center gap-2 text-sm">
+          <span className="text-zinc-500">Workflow</span>
+          <select
+            value={workflow}
+            onChange={(event) => onWorkflowChange(event.target.value as 'draft' | 'publish')}
+            className="rounded border border-zinc-300 px-2 py-1 text-sm focus:border-black focus:outline-none"
+          >
+            <option value="draft">Draft (PR)</option>
+            <option value="publish">Publish (commit)</option>
+          </select>
+        </div>
+        <div className="flex items-center gap-2 text-sm">
+          <span className="text-zinc-500">Commit message</span>
+          <input
+            value={message}
+            onChange={(event) => onMessageChange(event.target.value)}
+            className="min-w-[220px] rounded border border-zinc-300 px-2 py-1 text-sm focus:border-black focus:outline-none"
+            placeholder="Optional"
+          />
+        </div>
+        {unsaved ? <span className="text-xs font-medium uppercase tracking-wide text-amber-600">Unsaved changes</span> : null}
+      </div>
+
+      {state.format === 'markdown' ? (
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="flex flex-col gap-3">
+            {frontmatterFields.length === 0 ? (
+              <p className="text-sm text-zinc-500">No frontmatter fields configured.</p>
+            ) : (
+              frontmatterFields.map((field) => renderField(field))
+            )}
+          </div>
+          <div className="flex flex-col gap-2 md:col-span-2">
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-medium text-zinc-700">Body</span>
+              <ImageUploader
+                csrfToken={csrfToken}
+                onUploaded={(url) =>
+                  onChange({
+                    ...state,
+                    body: `${state.body}\n\n![image](${url})`,
+                  })
+                }
+                onError={onError}
+              />
+            </div>
+            <textarea
+              value={state.body}
+              onChange={(event) => onChange({ ...state, body: event.target.value })}
+              className="h-64 w-full rounded border border-zinc-300 px-3 py-2 text-sm font-mono focus:border-black focus:outline-none"
+            />
+          </div>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-2">
+          <span className="text-sm font-medium text-zinc-700">JSON</span>
+          <textarea
+            value={state.json}
+            onChange={(event) => onChange({ ...state, json: event.target.value })}
+            className="h-72 w-full rounded border border-zinc-300 px-3 py-2 text-sm font-mono focus:border-black focus:outline-none"
+          />
+        </div>
+      )}
+
+      <div className="flex items-center gap-3 pt-4">
+        <button
+          type="button"
+          onClick={onSave}
+          disabled={saving}
+          className={`rounded border border-black px-4 py-2 text-sm font-medium transition ${
+            saving ? 'bg-zinc-200 text-zinc-500' : 'text-black hover:bg-black hover:text-white'
+          }`}
+        >
+          {saving ? 'Saving…' : 'Save'}
+        </button>
+        <button
+          type="button"
+          onClick={onDelete}
+          className="rounded border border-red-500 px-4 py-2 text-sm font-medium text-red-600 transition hover:bg-red-600 hover:text-white"
+        >
+          Delete
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default Editor

--- a/components/EntryList.tsx
+++ b/components/EntryList.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+type Entry = {
+  slug: string
+  title: string
+  updatedAt: string | null
+}
+
+type Props = {
+  entries: Entry[]
+  selected: string | null
+  onSelect: (slug: string) => void
+  onCreate: () => void
+  search: string
+  onSearch: (value: string) => void
+}
+
+const formatDate = (value: string | null) => {
+  if (!value) return 'Unknown'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return 'Unknown'
+  }
+  return date.toLocaleString()
+}
+
+const EntryList = ({ entries, selected, onSelect, onCreate, search, onSearch }: Props) => {
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center gap-2 pb-3">
+        <input
+          value={search}
+          onChange={(event) => onSearch(event.target.value)}
+          className="w-full rounded border border-zinc-300 px-3 py-2 text-sm focus:border-black focus:outline-none"
+          placeholder="Search entries"
+        />
+        <button
+          type="button"
+          onClick={onCreate}
+          className="rounded border border-black px-3 py-2 text-sm font-medium text-black transition hover:bg-black hover:text-white"
+        >
+          New
+        </button>
+      </div>
+      <div className="flex-1 overflow-y-auto rounded border border-zinc-200 bg-white">
+        {entries.length === 0 ? (
+          <p className="p-4 text-sm text-zinc-500">No entries yet.</p>
+        ) : (
+          <ul className="divide-y divide-zinc-100">
+            {entries.map((entry) => (
+              <li key={entry.slug}>
+                <button
+                  type="button"
+                  onClick={() => onSelect(entry.slug)}
+                  className={`w-full px-3 py-3 text-left transition ${
+                    selected === entry.slug ? 'bg-black text-white' : 'hover:bg-zinc-100'
+                  }`}
+                >
+                  <div className="text-sm font-medium">{entry.title}</div>
+                  <div className={`text-xs ${selected === entry.slug ? 'text-zinc-200' : 'text-zinc-500'}`}>
+                    {entry.slug}
+                  </div>
+                  <div className={`text-xs ${selected === entry.slug ? 'text-zinc-300' : 'text-zinc-400'}`}>
+                    Updated {formatDate(entry.updatedAt)}
+                  </div>
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export type { Entry }
+export default EntryList

--- a/components/ImageUploader.tsx
+++ b/components/ImageUploader.tsx
@@ -1,0 +1,74 @@
+'use client'
+
+import { useRef, useState } from 'react'
+
+type Props = {
+  onUploaded: (url: string) => void
+  onError: (message: string) => void
+  csrfToken: string | null
+}
+
+const ImageUploader = ({ onUploaded, onError, csrfToken }: Props) => {
+  const inputRef = useRef<HTMLInputElement | null>(null)
+  const [uploading, setUploading] = useState(false)
+
+  const handleChange = async () => {
+    const input = inputRef.current
+    if (!input || !input.files || input.files.length === 0) {
+      return
+    }
+    const file = input.files[0]
+    const formData = new FormData()
+    formData.append('file', file)
+    setUploading(true)
+    try {
+      const init: RequestInit = {
+        method: 'POST',
+        body: formData,
+      }
+      if (csrfToken) {
+        init.headers = { 'x-csrf-token': csrfToken }
+      }
+      const response = await fetch('/api/admin/upload', init)
+      if (!response.ok) {
+        const error = await response.json().catch(() => ({ error: 'Upload failed' }))
+        throw new Error(error.error ?? 'Upload failed')
+      }
+      const json = await response.json()
+      if (json.url) {
+        onUploaded(json.url)
+      } else {
+        throw new Error('Upload failed')
+      }
+    } catch (error) {
+      onError((error as Error).message)
+    } finally {
+      input.value = ''
+      setUploading(false)
+    }
+  }
+
+  return (
+    <div>
+      <label className="inline-flex items-center gap-2 text-sm font-medium text-zinc-700">
+        <input
+          ref={inputRef}
+          type="file"
+          accept="image/*"
+          onChange={handleChange}
+          className="hidden"
+        />
+        <button
+          type="button"
+          onClick={() => inputRef.current?.click()}
+          className="rounded border border-zinc-300 px-3 py-1.5 text-sm font-medium text-zinc-700 transition hover:border-black hover:text-black"
+          disabled={uploading}
+        >
+          {uploading ? 'Uploading…' : 'Upload image'}
+        </button>
+      </label>
+    </div>
+  )
+}
+
+export default ImageUploader

--- a/lib/api/auth.ts
+++ b/lib/api/auth.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getAuthMode, getSessionFromRequest, isAllowlisted, OAuthSession } from '../auth'
+
+export type AuthResult =
+  | { ok: true; mode: 'token'; session: null }
+  | { ok: true; mode: 'oauth'; session: OAuthSession }
+  | { ok: false; response: NextResponse }
+
+export const ensureAuth = (req: NextRequest): AuthResult => {
+  const mode = getAuthMode()
+  if (mode === 'token') {
+    return { ok: true, mode: 'token', session: null }
+  }
+  const session = getSessionFromRequest(req)
+  if (!session) {
+    return { ok: false, response: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
+  }
+  if (!isAllowlisted(session)) {
+    return { ok: false, response: NextResponse.json({ error: 'Forbidden' }, { status: 403 }) }
+  }
+  return { ok: true, mode: 'oauth', session }
+}

--- a/lib/api/csrf.ts
+++ b/lib/api/csrf.ts
@@ -1,0 +1,48 @@
+import crypto from 'crypto'
+import { NextRequest, NextResponse } from 'next/server'
+
+const CSRF_COOKIE = 'cms_csrf'
+const CSRF_HEADER = 'x-csrf-token'
+const CSRF_TTL_SECONDS = 12 * 60 * 60
+
+export const readCsrfToken = (req: NextRequest) => req.cookies.get(CSRF_COOKIE)?.value ?? null
+
+export const createCsrfToken = () => crypto.randomBytes(32).toString('hex')
+
+export const setCsrfCookie = (res: NextResponse, token: string) => {
+  res.cookies.set({
+    name: CSRF_COOKIE,
+    value: token,
+    httpOnly: true,
+    sameSite: 'strict',
+    secure: process.env.NODE_ENV === 'production',
+    path: '/',
+    maxAge: CSRF_TTL_SECONDS,
+  })
+}
+
+export const ensureCsrfToken = (req: NextRequest, res: NextResponse) => {
+  const existing = readCsrfToken(req)
+  const token = existing ?? createCsrfToken()
+  setCsrfCookie(res, token)
+  return token
+}
+
+export const requireCsrfToken = (req: NextRequest) => {
+  const expected = readCsrfToken(req)
+  const provided = req.headers.get(CSRF_HEADER)
+  if (!expected || !provided) {
+    return NextResponse.json({ error: 'Invalid CSRF token' }, { status: 403 })
+  }
+  const expectedBuffer = Buffer.from(expected, 'utf8')
+  const providedBuffer = Buffer.from(provided, 'utf8')
+  if (expectedBuffer.length !== providedBuffer.length) {
+    return NextResponse.json({ error: 'Invalid CSRF token' }, { status: 403 })
+  }
+  if (!crypto.timingSafeEqual(expectedBuffer, providedBuffer)) {
+    return NextResponse.json({ error: 'Invalid CSRF token' }, { status: 403 })
+  }
+  return null
+}
+
+export const CSRF_HEADER_NAME = CSRF_HEADER

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,203 @@
+import crypto from 'crypto'
+import { cookies, headers } from 'next/headers'
+import { NextRequest, NextResponse } from 'next/server'
+
+export type AuthMode = 'oauth' | 'token'
+
+export type OAuthSession = {
+  name: string
+  email: string
+  login: string
+  accessToken: string
+  expiresAt: number
+}
+
+const SESSION_COOKIE = 'cms_session'
+const STATE_COOKIE = 'cms_oauth_state'
+const SESSION_TTL_MS = 12 * 60 * 60 * 1000
+
+const getSecret = () => {
+  const secret = process.env.NEXTAUTH_SECRET
+  if (!secret || secret.length < 16) {
+    throw new Error('NEXTAUTH_SECRET must be configured and at least 16 characters long')
+  }
+  return secret
+}
+
+const base64url = (input: Buffer | string) =>
+  Buffer.from(input)
+    .toString('base64')
+    .replace(/=+$/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+
+const sign = (payload: Record<string, unknown>) => {
+  const body = base64url(Buffer.from(JSON.stringify(payload)))
+  const signature = base64url(crypto.createHmac('sha256', getSecret()).update(body).digest())
+  return `${body}.${signature}`
+}
+
+const verify = <TPayload extends Record<string, unknown>>(token: string): TPayload | null => {
+  const [body, signature] = token.split('.')
+  if (!body || !signature) {
+    return null
+  }
+  const expected = base64url(crypto.createHmac('sha256', getSecret()).update(body).digest())
+  if (!crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(expected))) {
+    return null
+  }
+  try {
+    const payload = JSON.parse(Buffer.from(body, 'base64').toString()) as TPayload
+    return payload
+  } catch {
+    return null
+  }
+}
+
+export const getAuthMode = (): AuthMode => {
+  const value = (process.env.CMS_AUTH_MODE ?? 'oauth').toLowerCase()
+  return value === 'token' ? 'token' : 'oauth'
+}
+
+export const isTokenMode = () => getAuthMode() === 'token'
+
+const parseAllowlist = (value?: string) =>
+  value
+    ?.split(',')
+    .map((entry) => entry.trim().toLowerCase())
+    .filter(Boolean) ?? []
+
+const allowedEmails = () => parseAllowlist(process.env.ALLOWED_EMAILS)
+const allowedLogins = () => parseAllowlist(process.env.ALLOWED_GITHUB_LOGINS)
+
+export const isAllowlisted = (user: { email?: string | null; login?: string | null }) => {
+  const emails = allowedEmails()
+  const logins = allowedLogins()
+  if (emails.length === 0 && logins.length === 0) {
+    return true
+  }
+  const email = user.email?.toLowerCase()
+  const login = user.login?.toLowerCase()
+  if (email && emails.includes(email)) {
+    return true
+  }
+  if (login && logins.includes(login)) {
+    return true
+  }
+  return false
+}
+
+export const createSession = (user: { name: string; email: string; login: string; accessToken: string }) => {
+  const session: OAuthSession = {
+    ...user,
+    expiresAt: Date.now() + SESSION_TTL_MS,
+  }
+  return sign(session)
+}
+
+export const readSession = (token: string | undefined): OAuthSession | null => {
+  if (!token) {
+    return null
+  }
+  const payload = verify<OAuthSession>(token)
+  if (!payload || typeof payload !== 'object') {
+    return null
+  }
+  if (payload.expiresAt && payload.expiresAt < Date.now()) {
+    return null
+  }
+  return payload
+}
+
+export const getSessionFromRequest = (req: NextRequest): OAuthSession | null => {
+  const token = req.cookies.get(SESSION_COOKIE)?.value
+  return readSession(token)
+}
+
+export const getSessionFromCookies = (): OAuthSession | null => {
+  try {
+    const store = cookies()
+    const token = store.get(SESSION_COOKIE)?.value
+    return readSession(token)
+  } catch {
+    return null
+  }
+}
+
+export const setSessionCookie = (res: NextResponse, token: string) => {
+  res.cookies.set({
+    name: SESSION_COOKIE,
+    value: token,
+    httpOnly: true,
+    path: '/',
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
+    maxAge: SESSION_TTL_MS / 1000,
+  })
+}
+
+export const clearSessionCookie = (res: NextResponse) => {
+  res.cookies.set({
+    name: SESSION_COOKIE,
+    value: '',
+    httpOnly: true,
+    path: '/',
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
+    maxAge: 0,
+  })
+}
+
+export const createStateToken = () => crypto.randomBytes(16).toString('hex')
+
+export const setStateCookie = (res: NextResponse, state: string) => {
+  res.cookies.set({
+    name: STATE_COOKIE,
+    value: state,
+    httpOnly: true,
+    path: '/api/auth',
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
+    maxAge: 10 * 60,
+  })
+}
+
+export const readStateFromRequest = (req: NextRequest) => req.cookies.get(STATE_COOKIE)?.value
+
+export const clearStateCookie = (res: NextResponse) => {
+  res.cookies.set({
+    name: STATE_COOKIE,
+    value: '',
+    httpOnly: true,
+    path: '/api/auth',
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
+    maxAge: 0,
+  })
+}
+
+export const requireBasicAuth = (req: NextRequest) => {
+  const user = process.env.BASIC_AUTH_USER
+  const pass = process.env.BASIC_AUTH_PASS
+  if (!user || !pass) {
+    return NextResponse.next()
+  }
+  const header = req.headers.get('authorization')
+  if (!header || !header.startsWith('Basic ')) {
+    return new NextResponse('Unauthorized', {
+      status: 401,
+      headers: { 'WWW-Authenticate': 'Basic realm="Palestine CMS"' },
+    })
+  }
+  const decoded = Buffer.from(header.slice(6), 'base64').toString()
+  const [name, password] = decoded.split(':')
+  if (name !== user || password !== pass) {
+    return new NextResponse('Unauthorized', {
+      status: 401,
+      headers: { 'WWW-Authenticate': 'Basic realm="Palestine CMS"' },
+    })
+  }
+  return NextResponse.next()
+}
+
+export const getUserAgent = () => headers().get('user-agent') ?? 'cms-admin'

--- a/lib/collections.ts
+++ b/lib/collections.ts
@@ -1,0 +1,179 @@
+import path from 'path'
+import { z } from './zod'
+
+export type Workflow = 'draft' | 'publish'
+export type CollectionFormat = 'markdown' | 'json'
+
+export type CollectionDefinition = {
+  id: string
+  label: string
+  directory: string
+  extension: '.md' | '.json'
+  format: CollectionFormat
+  schema: ReturnType<typeof z.object>
+  defaultWorkflow: Workflow
+  slugField: string
+  bodyField?: string
+  fields: { name: string; type: string; required?: boolean }[]
+}
+
+export const collections: CollectionDefinition[] = [
+  {
+    id: 'chapters_en',
+    label: 'Chapters (English)',
+    directory: 'content/chapters/en',
+    extension: '.md',
+    format: 'markdown',
+    schema: z.object({
+      title: z.string().nonempty('Title is required'),
+      slug: z.string().nonempty('Slug is required'),
+      date: z.string().optional(),
+      tags: z.array(z.string()).optional(),
+      summary: z.string().optional(),
+    }),
+    defaultWorkflow: 'draft',
+    slugField: 'slug',
+    bodyField: 'body',
+    fields: [
+      { name: 'title', type: 'string', required: true },
+      { name: 'slug', type: 'string', required: true },
+      { name: 'date', type: 'string' },
+      { name: 'tags', type: 'string[]' },
+      { name: 'summary', type: 'string' },
+      { name: 'body', type: 'markdown' },
+    ],
+  },
+  {
+    id: 'chapters_ar',
+    label: 'Chapters (Arabic)',
+    directory: 'content/chapters/ar',
+    extension: '.md',
+    format: 'markdown',
+    schema: z.object({
+      title: z.string().nonempty('Title is required'),
+      slug: z.string().nonempty('Slug is required'),
+      date: z.string().optional(),
+      tags: z.array(z.string()).optional(),
+      summary: z.string().optional(),
+    }),
+    defaultWorkflow: 'draft',
+    slugField: 'slug',
+    bodyField: 'body',
+    fields: [
+      { name: 'title', type: 'string', required: true },
+      { name: 'slug', type: 'string', required: true },
+      { name: 'date', type: 'string' },
+      { name: 'tags', type: 'string[]' },
+      { name: 'summary', type: 'string' },
+      { name: 'body', type: 'markdown' },
+    ],
+  },
+  {
+    id: 'timeline_content',
+    label: 'Timeline Content',
+    directory: 'content/timeline/content',
+    extension: '.md',
+    format: 'markdown',
+    schema: z.object({
+      title: z.string().nonempty(),
+      slug: z.string().nonempty(),
+      era: z.string().optional(),
+      featured: z.boolean().optional(),
+    }),
+    defaultWorkflow: 'draft',
+    slugField: 'slug',
+    bodyField: 'body',
+    fields: [
+      { name: 'title', type: 'string', required: true },
+      { name: 'slug', type: 'string', required: true },
+      { name: 'era', type: 'string' },
+      { name: 'featured', type: 'boolean' },
+      { name: 'body', type: 'markdown' },
+    ],
+  },
+  {
+    id: 'timeline_data',
+    label: 'Timeline Data',
+    directory: 'content/timeline/data',
+    extension: '.json',
+    format: 'json',
+    schema: z.object({
+      slug: z.string().nonempty(),
+      title: z.string().nonempty(),
+      date: z.string().optional(),
+      events: z.array(
+        z.object({
+          id: z.string().nonempty(),
+          label: z.string().nonempty(),
+          description: z.string().optional(),
+          date: z.string().optional(),
+        }),
+      ),
+    }),
+    defaultWorkflow: 'publish',
+    slugField: 'slug',
+    fields: [
+      { name: 'slug', type: 'string', required: true },
+      { name: 'title', type: 'string', required: true },
+      { name: 'date', type: 'string' },
+      { name: 'events', type: 'Event[]' },
+    ],
+  },
+  {
+    id: 'bibliography',
+    label: 'Bibliography',
+    directory: 'content/bibliography',
+    extension: '.md',
+    format: 'markdown',
+    schema: z.object({
+      title: z.string().nonempty(),
+      slug: z.string().nonempty(),
+      authors: z.array(z.string()).optional(),
+      year: z.string().optional(),
+    }),
+    defaultWorkflow: 'publish',
+    slugField: 'slug',
+    bodyField: 'body',
+    fields: [
+      { name: 'title', type: 'string', required: true },
+      { name: 'slug', type: 'string', required: true },
+      { name: 'authors', type: 'string[]' },
+      { name: 'year', type: 'string' },
+      { name: 'body', type: 'markdown' },
+    ],
+  },
+  {
+    id: 'gazetteer',
+    label: 'Gazetteer',
+    directory: 'content/gazetteer',
+    extension: '.md',
+    format: 'markdown',
+    schema: z.object({
+      title: z.string().nonempty(),
+      slug: z.string().nonempty(),
+      region: z.string().optional(),
+      coordinates: z.array(z.number()).optional(),
+    }),
+    defaultWorkflow: 'publish',
+    slugField: 'slug',
+    bodyField: 'body',
+    fields: [
+      { name: 'title', type: 'string', required: true },
+      { name: 'slug', type: 'string', required: true },
+      { name: 'region', type: 'string' },
+      { name: 'coordinates', type: 'number[]' },
+      { name: 'body', type: 'markdown' },
+    ],
+  },
+]
+
+export type CollectionId = (typeof collections)[number]['id']
+
+export const getCollection = (id: string) => collections.find((collection) => collection.id === id)
+
+export const getEntryPath = (collection: CollectionDefinition, slug: string, extension?: string) => {
+  const ext = extension ?? collection.extension
+  return path.posix.join(collection.directory, `${slug}${ext}`)
+}
+
+export const listCollectionIds = () => collections.map((collection) => collection.id)

--- a/lib/content.ts
+++ b/lib/content.ts
@@ -1,0 +1,108 @@
+import { CollectionDefinition, getEntryPath } from './collections'
+import { parseMarkdown, serializeMarkdown } from './md'
+import { getFile, getLatestCommitForPath, listDirectory, type GitHubClient } from './github'
+
+export type ParsedEntry = {
+  frontmatter: Record<string, unknown>
+  body?: string
+  data?: Record<string, unknown> | unknown
+  sha: string
+  path: string
+  raw: string
+}
+
+export type EntrySummary = {
+  path: string
+  slug: string
+  title: string
+  updatedAt: string | null
+}
+
+const decodeContent = (encoded: string, encoding: string) => {
+  if (encoding !== 'base64') {
+    throw new Error(`Unsupported encoding ${encoding}`)
+  }
+  return Buffer.from(encoded, 'base64').toString('utf-8')
+}
+
+export const readEntry = async (
+  client: GitHubClient,
+  collection: CollectionDefinition,
+  slug: string,
+  branch?: string,
+): Promise<ParsedEntry> => {
+  const file = await getFile(client, getEntryPath(collection, slug), branch).catch(() => null)
+  if (!file) {
+    throw new Error('Not Found')
+  }
+  const raw = decodeContent(file.content, file.encoding)
+  if (collection.format === 'markdown') {
+    const parsed = parseMarkdown<Record<string, unknown>>(raw)
+    const validation = collection.schema.safeParse(parsed.frontmatter)
+    if (!validation.success) {
+      throw validation.error
+    }
+    return {
+      frontmatter: validation.data,
+      body: parsed.body,
+      path: getEntryPath(collection, slug),
+      sha: file.sha,
+      raw,
+    }
+  }
+  const data = JSON.parse(raw)
+  const validation = collection.schema.safeParse(data)
+  if (!validation.success) {
+    throw validation.error
+  }
+  return {
+    frontmatter: validation.data as Record<string, unknown>,
+    data: validation.data,
+    path: getEntryPath(collection, slug, '.json'),
+    sha: file.sha,
+    raw,
+  }
+}
+
+export const serializeEntry = (
+  collection: CollectionDefinition,
+  payload: { frontmatter: Record<string, unknown>; body?: string; data?: unknown },
+) => {
+  if (collection.format === 'markdown') {
+    return serializeMarkdown({ frontmatter: payload.frontmatter, body: payload.body ?? '' })
+  }
+  return `${JSON.stringify(payload.data ?? payload.frontmatter, null, 2)}\n`
+}
+
+export const listEntries = async (
+  client: GitHubClient,
+  collection: CollectionDefinition,
+  branch?: string,
+): Promise<EntrySummary[]> => {
+  const entries = await listDirectory(client, collection.directory, branch).catch(() => [])
+  const files = entries.filter((entry) => entry.type === 'file' && entry.name.endsWith(collection.extension))
+  const summaries: EntrySummary[] = []
+  for (const file of files) {
+    const slug = file.name.slice(0, -collection.extension.length)
+    try {
+      const parsed = await readEntry(client, collection, slug, branch)
+      const title = (parsed.frontmatter?.title as string | undefined) ?? slug
+      const commit = await getLatestCommitForPath(client, parsed.path, branch)
+      summaries.push({
+        path: parsed.path,
+        slug,
+        title,
+        updatedAt: commit?.commit?.committer?.date ?? null,
+      })
+    } catch {
+      continue
+    }
+  }
+  summaries.sort((a, b) => {
+    if (!a.updatedAt && !b.updatedAt) return a.slug.localeCompare(b.slug)
+    if (!a.updatedAt) return 1
+    if (!b.updatedAt) return -1
+    return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+  })
+  return summaries
+}

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -1,0 +1,256 @@
+import { NextRequest } from 'next/server'
+import { getAuthMode, getSessionFromRequest, isAllowlisted, OAuthSession } from './auth'
+
+const GITHUB_API = 'https://api.github.com'
+
+type RepoConfig = {
+  owner: string
+  repo: string
+  defaultBranch: string
+}
+
+export type GitHubClient = {
+  request<T>(method: string, path: string, init?: RequestInit & { asJson?: boolean }): Promise<T>
+  token: string
+  sessionUser?: OAuthSession
+}
+
+const getRepoConfig = (): RepoConfig => {
+  const repo = process.env.CMS_GITHUB_REPO
+  if (!repo || !repo.includes('/')) {
+    throw new Error('CMS_GITHUB_REPO must be set as owner/repo')
+  }
+  const [owner, name] = repo.split('/')
+  const defaultBranch = process.env.CMS_GITHUB_BRANCH ?? 'main'
+  return { owner, repo: name, defaultBranch }
+}
+
+const getUserAgent = () => process.env.CMS_USER_AGENT ?? 'palestine-cms-admin'
+
+const createClient = (token: string, sessionUser?: OAuthSession): GitHubClient => {
+  return {
+    token,
+    sessionUser,
+    async request(method, path, init = {}) {
+      const url = `${GITHUB_API}${path}`
+      const headers: HeadersInit = {
+        Accept: 'application/vnd.github+json',
+        Authorization: `Bearer ${token}`,
+        'User-Agent': getUserAgent(),
+      }
+      const body = init.body
+      const response = await fetch(url, {
+        method,
+        headers: body instanceof FormData ? headers : { ...headers, 'Content-Type': 'application/json' },
+        body: body instanceof FormData ? body : body ? JSON.stringify(body) : undefined,
+      })
+      if (response.status >= 200 && response.status < 300) {
+        if (response.status === 204) {
+          return undefined as T
+        }
+        if (init.asJson === false) {
+          // @ts-ignore
+          return (await response.text()) as T
+        }
+        return (await response.json()) as T
+      }
+      const text = await response.text()
+      throw new Error(`GitHub API ${method} ${path} failed: ${response.status} ${text}`)
+    },
+  }
+}
+
+export const resolveCommitAuthor = (session?: OAuthSession) => {
+  if (session) {
+    return {
+      name: session.name || session.login,
+      email: session.email || `${session.login}@users.noreply.github.com`,
+    }
+  }
+  return {
+    name: process.env.CMS_COMMIT_AUTHOR_NAME ?? 'Palestine CMS Bot',
+    email: process.env.CMS_COMMIT_AUTHOR_EMAIL ?? 'cms@palestine-solidarity.local',
+  }
+}
+
+export const getOctokitForRequest = (req: NextRequest): GitHubClient => {
+  const mode = getAuthMode()
+  if (mode === 'token') {
+    const token = process.env.CMS_GITHUB_TOKEN
+    if (!token) {
+      throw new Error('CMS_GITHUB_TOKEN must be configured in token mode')
+    }
+    return createClient(token)
+  }
+  const session = getSessionFromRequest(req)
+  if (!session) {
+    throw new Error('Unauthorized')
+  }
+  if (!isAllowlisted(session)) {
+    throw new Error('Forbidden')
+  }
+  return createClient(session.accessToken, session)
+}
+
+export const ensureBranch = async (client: GitHubClient, branch: string, fromBranch?: string) => {
+  const { owner, repo, defaultBranch } = getRepoConfig()
+  const baseBranch = fromBranch ?? defaultBranch
+  try {
+    await client.request('GET', `/repos/${owner}/${repo}/git/ref/heads/${branch}`)
+    return
+  } catch (error) {
+    // create branch from base
+  }
+  const baseRef = await client.request<{ object: { sha: string } }>(
+    'GET',
+    `/repos/${owner}/${repo}/git/ref/heads/${baseBranch}`,
+  )
+  await client.request('POST', `/repos/${owner}/${repo}/git/refs`, {
+    body: {
+      ref: `refs/heads/${branch}`,
+      sha: baseRef.object.sha,
+    },
+  })
+}
+
+type FileContentResponse = {
+  sha: string
+  content: string
+  encoding: string
+  path: string
+}
+
+export const getFile = async (client: GitHubClient, path: string, branch?: string) => {
+  const { owner, repo, defaultBranch } = getRepoConfig()
+  const ref = branch ?? defaultBranch
+  return client.request<FileContentResponse>(
+    'GET',
+    `/repos/${owner}/${repo}/contents/${encodeURIComponent(path).replace(/%2F/g, '/')}` + `?ref=${ref}`,
+  )
+}
+
+export const putFile = async (
+  client: GitHubClient,
+  path: string,
+  content: string | Buffer,
+  message: string,
+  branch?: string,
+  sha?: string,
+  author?: { name: string; email: string },
+) => {
+  const { owner, repo, defaultBranch } = getRepoConfig()
+  const ref = branch ?? defaultBranch
+  const payload = Buffer.isBuffer(content) ? content : Buffer.from(content)
+  const body: Record<string, unknown> = {
+    message,
+    content: payload.toString('base64'),
+    branch: ref,
+  }
+  if (sha) {
+    body.sha = sha
+  }
+  if (author) {
+    body.committer = author
+    body.author = author
+  }
+  const encoded = encodeURIComponent(path).replace(/%2F/g, '/')
+  return client.request('PUT', `/repos/${owner}/${repo}/contents/${encoded}`, { body })
+}
+
+export const deleteFile = async (
+  client: GitHubClient,
+  path: string,
+  message: string,
+  branch?: string,
+  sha?: string,
+  author?: { name: string; email: string },
+) => {
+  const { owner, repo, defaultBranch } = getRepoConfig()
+  const ref = branch ?? defaultBranch
+  const body: Record<string, unknown> = {
+    message,
+    branch: ref,
+  }
+  if (sha) {
+    body.sha = sha
+  }
+  if (author) {
+    body.committer = author
+    body.author = author
+  }
+  const encoded = encodeURIComponent(path).replace(/%2F/g, '/')
+  return client.request('DELETE', `/repos/${owner}/${repo}/contents/${encoded}`, { body })
+}
+
+export const listDirectory = async (client: GitHubClient, directory: string, branch?: string) => {
+  const { owner, repo, defaultBranch } = getRepoConfig()
+  const ref = branch ?? defaultBranch
+  return client.request<
+    {
+      name: string
+      path: string
+      sha: string
+      type: 'file' | 'dir'
+    }[]
+  >(
+    'GET',
+    `/repos/${owner}/${repo}/contents/${encodeURIComponent(directory).replace(/%2F/g, '/')}` + `?ref=${ref}`,
+  )
+}
+
+export const getLatestCommitForPath = async (client: GitHubClient, path: string, branch?: string) => {
+  const { owner, repo, defaultBranch } = getRepoConfig()
+  const ref = branch ?? defaultBranch
+  const commits = await client.request<
+    { sha: string; commit: { committer: { date: string } } }[]
+  >(
+    'GET',
+    `/repos/${owner}/${repo}/commits?path=${encodeURIComponent(path)}&sha=${ref}&per_page=1`,
+  )
+  return commits[0]
+}
+
+type PullRequest = {
+  number: number
+  html_url: string
+  head: { ref: string }
+}
+
+export const findPullRequestByBranch = async (client: GitHubClient, branch: string) => {
+  const { owner, repo } = getRepoConfig()
+  const prs = await client.request<PullRequest[]>(
+    'GET',
+    `/repos/${owner}/${repo}/pulls?state=open&head=${owner}:${encodeURIComponent(branch)}`,
+  )
+  return prs.find((pr) => pr.head.ref === branch)
+}
+
+export const createPullRequest = async (
+  client: GitHubClient,
+  branch: string,
+  title: string,
+  body: string,
+) => {
+  const { owner, repo, defaultBranch } = getRepoConfig()
+  return client.request<PullRequest>('POST', `/repos/${owner}/${repo}/pulls`, {
+    body: {
+      title,
+      head: branch,
+      base: defaultBranch,
+      body,
+    },
+  })
+}
+
+export const updatePullRequestBody = async (client: GitHubClient, number: number, body: string) => {
+  const { owner, repo } = getRepoConfig()
+  return client.request<PullRequest>('PATCH', `/repos/${owner}/${repo}/pulls/${number}`, {
+    body: { body },
+  })
+}
+
+export const getRawFileUrl = (path: string, branch?: string) => {
+  const { owner, repo, defaultBranch } = getRepoConfig()
+  const ref = branch ?? defaultBranch
+  return `https://raw.githubusercontent.com/${owner}/${repo}/${ref}/${path}`
+}

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -213,7 +213,7 @@ export const getLatestCommitForPath = async (client: GitHubClient, path: string,
     { sha: string; commit: { committer: { date: string } } }[]
   >(
     'GET',
-    `/repos/${owner}/${repo}/commits?path=${encodeURIComponent(path)}&sha=${ref}&per_page=1`,
+    `/repos/${owner}/${repo}/commits?path=${encodeURIComponent(path)}&sha=${encodeURIComponent(ref)}&per_page=1`,
   )
   return commits[0]
 }
@@ -228,7 +228,7 @@ export const findPullRequestByBranch = async (client: GitHubClient, branch: stri
   const { owner, repo } = getRepoConfig()
   const prs = await client.request<PullRequest[]>(
     'GET',
-    `/repos/${owner}/${repo}/pulls?state=open&head=${owner}:${encodeURIComponent(branch)}`,
+    `/repos/${owner}/${repo}/pulls?state=open&head=${encodeURIComponent(owner)}:${encodeURIComponent(branch)}`,
   )
   return prs.find((pr) => pr.head.ref === branch)
 }

--- a/lib/md.ts
+++ b/lib/md.ts
@@ -1,0 +1,36 @@
+import matter from 'gray-matter'
+import { unified } from 'unified'
+import remarkParse from 'remark-parse'
+
+export type MarkdownDocument<TFrontmatter extends Record<string, unknown>> = {
+  frontmatter: TFrontmatter
+  body: string
+}
+
+const remarkProcessor = unified().use(remarkParse)
+
+export const parseMarkdown = <TFrontmatter extends Record<string, unknown>>(
+  raw: string,
+): MarkdownDocument<TFrontmatter> => {
+  const parsed = matter(raw)
+  return {
+    frontmatter: parsed.data as TFrontmatter,
+    body: parsed.content.trimEnd(),
+  }
+}
+
+export const serializeMarkdown = <TFrontmatter extends Record<string, unknown>>({
+  frontmatter,
+  body,
+}: MarkdownDocument<TFrontmatter>) => {
+  remarkProcessor.parse(body ?? '')
+  const formattedBody = `${(body ?? '').trim()}\n`
+  const cleaned: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(frontmatter)) {
+    if (value !== undefined) {
+      cleaned[key] = value
+    }
+  }
+  const serialized = matter.stringify(formattedBody, cleaned)
+  return serialized.endsWith('\n') ? serialized : `${serialized}\n`
+}

--- a/lib/octokit.ts
+++ b/lib/octokit.ts
@@ -1,0 +1,1 @@
+export { getOctokitForRequest, type GitHubClient } from './github'

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -1,0 +1,20 @@
+type Entry = {
+  count: number
+  resetAt: number
+}
+
+const store = new Map<string, Entry>()
+
+export const rateLimit = (key: string, limit: number, windowMs: number) => {
+  const now = Date.now()
+  const existing = store.get(key)
+  if (!existing || existing.resetAt < now) {
+    store.set(key, { count: 1, resetAt: now + windowMs })
+    return { success: true }
+  }
+  if (existing.count >= limit) {
+    return { success: false, retryAfter: Math.max(0, existing.resetAt - now) }
+  }
+  existing.count += 1
+  return { success: true }
+}

--- a/lib/slugs.ts
+++ b/lib/slugs.ts
@@ -1,0 +1,16 @@
+const ASCII_DIACRITICS = /[\u0300-\u036f]/g
+
+export const slugify = (value: string) => {
+  return value
+    .normalize('NFD')
+    .replace(ASCII_DIACRITICS, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .trim()
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+}
+
+export const sanitizeFilename = (value: string) => {
+  return value.replace(/[^a-zA-Z0-9._-]/g, '')
+}

--- a/lib/zod.ts
+++ b/lib/zod.ts
@@ -1,0 +1,292 @@
+import crypto from 'crypto'
+
+type Issue = {
+  path: (string | number)[]
+  message: string
+}
+
+export class ZodError extends Error {
+  issues: Issue[]
+
+  constructor(issues: Issue[]) {
+    super(issues.map((issue) => issue.message).join('\n'))
+    this.name = 'ZodError'
+    this.issues = issues
+  }
+}
+
+export type ParseResult<T> =
+  | { success: true; data: T }
+  | { success: false; error: ZodError }
+
+export interface ZodSchema<T> {
+  parse(input: unknown): T
+  safeParse(input: unknown): ParseResult<T>
+  optional(): ZodSchema<T | undefined>
+  default(value: T): ZodSchema<T>
+}
+
+abstract class BaseSchema<T> implements ZodSchema<T> {
+  abstract _parse(input: unknown, path: (string | number)[]): T
+
+  parse(input: unknown): T {
+    return this._parse(input, [])
+  }
+
+  safeParse(input: unknown): ParseResult<T> {
+    try {
+      return { success: true, data: this.parse(input) }
+    } catch (error) {
+      if (error instanceof ZodError) {
+        return { success: false, error }
+      }
+      throw error
+    }
+  }
+
+  optional(): ZodSchema<T | undefined> {
+    const inner = this
+    return new (class extends BaseSchema<T | undefined> {
+      _parse(input: unknown, path: (string | number)[]): T | undefined {
+        if (input === undefined || input === null) {
+          return undefined
+        }
+        return inner._parse(input, path)
+      }
+    })()
+  }
+
+  default(value: T): ZodSchema<T> {
+    const inner = this
+    return new (class extends BaseSchema<T> {
+      _parse(input: unknown, path: (string | number)[]): T {
+        if (input === undefined || input === null || input === '') {
+          return typeof value === 'function' ? (value as unknown as () => T)() : value
+        }
+        return inner._parse(input, path)
+      }
+    })()
+  }
+}
+
+class ZodString extends BaseSchema<string> {
+  private checks: ((value: string, path: (string | number)[]) => void)[] = []
+
+  _parse(input: unknown, path: (string | number)[]): string {
+    if (typeof input !== 'string') {
+      throw new ZodError([{ path, message: 'Expected string' }])
+    }
+    for (const check of this.checks) {
+      check(input, path)
+    }
+    return input
+  }
+
+  nonempty(message = 'Required'): ZodString {
+    this.checks.push((value, path) => {
+      if (value.trim().length === 0) {
+        throw new ZodError([{ path, message }])
+      }
+    })
+    return this
+  }
+
+  min(length: number, message?: string): ZodString {
+    this.checks.push((value, path) => {
+      if (value.length < length) {
+        throw new ZodError([{ path, message: message ?? `Must be at least ${length} characters` }])
+      }
+    })
+    return this
+  }
+
+  max(length: number, message?: string): ZodString {
+    this.checks.push((value, path) => {
+      if (value.length > length) {
+        throw new ZodError([{ path, message: message ?? `Must be at most ${length} characters` }])
+      }
+    })
+    return this
+  }
+
+  regex(regex: RegExp, message = 'Invalid format'): ZodString {
+    this.checks.push((value, path) => {
+      if (!regex.test(value)) {
+        throw new ZodError([{ path, message }])
+      }
+    })
+    return this
+  }
+
+  email(message = 'Invalid email'): ZodString {
+    return this.regex(/^[^\s@]+@[^\s@]+\.[^\s@]+$/, message)
+  }
+}
+
+class ZodBoolean extends BaseSchema<boolean> {
+  _parse(input: unknown, path: (string | number)[]): boolean {
+    if (typeof input !== 'boolean') {
+      throw new ZodError([{ path, message: 'Expected boolean' }])
+    }
+    return input
+  }
+}
+
+class ZodNumber extends BaseSchema<number> {
+  _parse(input: unknown, path: (string | number)[]): number {
+    if (typeof input !== 'number' || Number.isNaN(input)) {
+      throw new ZodError([{ path, message: 'Expected number' }])
+    }
+    return input
+  }
+}
+
+class ZodArray<T> extends BaseSchema<T[]> {
+  constructor(private readonly element: BaseSchema<T>) {
+    super()
+  }
+
+  _parse(input: unknown, path: (string | number)[]): T[] {
+    if (!Array.isArray(input)) {
+      throw new ZodError([{ path, message: 'Expected array' }])
+    }
+    return input.map((value, index) => this.element._parse(value, [...path, index]))
+  }
+}
+
+class ZodLiteral<T> extends BaseSchema<T> {
+  constructor(private readonly literal: T) {
+    super()
+  }
+
+  _parse(input: unknown, path: (string | number)[]): T {
+    if (input !== this.literal) {
+      throw new ZodError([{ path, message: `Expected literal ${this.literal}` }])
+    }
+    return this.literal
+  }
+}
+
+class ZodEnum<T extends readonly [string, ...string[]]> extends BaseSchema<T[number]> {
+  constructor(private readonly values: T) {
+    super()
+  }
+
+  _parse(input: unknown, path: (string | number)[]): T[number] {
+    if (typeof input !== 'string' || !this.values.includes(input as T[number])) {
+      throw new ZodError([{ path, message: `Expected one of: ${this.values.join(', ')}` }])
+    }
+    return input as T[number]
+  }
+}
+
+class ZodRecord<T> extends BaseSchema<Record<string, T>> {
+  constructor(private readonly valueSchema: BaseSchema<T>) {
+    super()
+  }
+
+  _parse(input: unknown, path: (string | number)[]): Record<string, T> {
+    if (typeof input !== 'object' || input === null || Array.isArray(input)) {
+      throw new ZodError([{ path, message: 'Expected object' }])
+    }
+    const result: Record<string, T> = {}
+    for (const [key, value] of Object.entries(input as Record<string, unknown>)) {
+      result[key] = this.valueSchema._parse(value, [...path, key])
+    }
+    return result
+  }
+}
+
+class ZodObject<T extends Record<string, any>> extends BaseSchema<T> {
+  constructor(private readonly shape: { [K in keyof T]: BaseSchema<T[K]> }) {
+    super()
+  }
+
+  _parse(input: unknown, path: (string | number)[]): T {
+    if (typeof input !== 'object' || input === null || Array.isArray(input)) {
+      throw new ZodError([{ path, message: 'Expected object' }])
+    }
+    const entries = input as Record<string, unknown>
+    const result: Record<string, unknown> = {}
+    const issues: Issue[] = []
+    for (const key of Object.keys(this.shape)) {
+      const schema = this.shape[key]
+      try {
+        result[key] = schema._parse(entries[key], [...path, key])
+      } catch (error) {
+        if (error instanceof ZodError) {
+          issues.push(...error.issues)
+        } else {
+          throw error
+        }
+      }
+    }
+    if (issues.length > 0) {
+      throw new ZodError(issues)
+    }
+    return result as T
+  }
+}
+
+class ZodUnion<T> extends BaseSchema<T> {
+  constructor(private readonly options: BaseSchema<any>[]) {
+    super()
+  }
+
+  _parse(input: unknown, path: (string | number)[]): T {
+    const issues: Issue[] = []
+    for (const option of this.options) {
+      try {
+        return option._parse(input, path)
+      } catch (error) {
+        if (error instanceof ZodError) {
+          issues.push(...error.issues)
+        } else {
+          throw error
+        }
+      }
+    }
+    throw new ZodError(issues.length ? issues : [{ path, message: 'Invalid input' }])
+  }
+}
+
+class ZodEffects<I, O> extends BaseSchema<O> {
+  constructor(private readonly schema: BaseSchema<I>, private readonly transform: (input: I) => O) {
+    super()
+  }
+
+  _parse(input: unknown, path: (string | number)[]): O {
+    const parsed = this.schema._parse(input, path)
+    return this.transform(parsed)
+  }
+}
+
+const string = () => new ZodString()
+const boolean = () => new ZodBoolean()
+const number = () => new ZodNumber()
+const array = <T>(schema: BaseSchema<T>) => new ZodArray(schema)
+const literal = <T>(value: T) => new ZodLiteral(value)
+const enumeration = <T extends readonly [string, ...string[]]>(values: T) => new ZodEnum(values)
+const record = <T>(schema: BaseSchema<T>) => new ZodRecord(schema)
+const object = <T extends Record<string, any>>(shape: { [K in keyof T]: BaseSchema<T[K]> }) =>
+  new ZodObject(shape)
+const union = <T>(options: BaseSchema<any>[]) => new ZodUnion<T>(options)
+const effects = <I, O>(schema: BaseSchema<I>, transform: (input: I) => O) => new ZodEffects(schema, transform)
+
+export const z = {
+  string,
+  boolean,
+  number,
+  array,
+  object,
+  literal,
+  enum: enumeration,
+  record,
+  union,
+  effects,
+  ZodError,
+}
+
+export type infer<T extends ZodSchema<any>> = T extends ZodSchema<infer U> ? U : never
+
+export const createId = () => crypto.randomBytes(16).toString('hex')

--- a/lib/zod.ts
+++ b/lib/zod.ts
@@ -19,14 +19,7 @@ export type ParseResult<T> =
   | { success: true; data: T }
   | { success: false; error: ZodError }
 
-export interface ZodSchema<T> {
-  parse(input: unknown): T
-  safeParse(input: unknown): ParseResult<T>
-  optional(): ZodSchema<T | undefined>
-  default(value: T): ZodSchema<T>
-}
-
-abstract class BaseSchema<T> implements ZodSchema<T> {
+abstract class BaseSchema<T> {
   abstract _parse(input: unknown, path: (string | number)[]): T
 
   parse(input: unknown): T {
@@ -44,7 +37,7 @@ abstract class BaseSchema<T> implements ZodSchema<T> {
     }
   }
 
-  optional(): ZodSchema<T | undefined> {
+  optional(): BaseSchema<T | undefined> {
     const inner = this
     return new (class extends BaseSchema<T | undefined> {
       _parse(input: unknown, path: (string | number)[]): T | undefined {
@@ -56,7 +49,7 @@ abstract class BaseSchema<T> implements ZodSchema<T> {
     })()
   }
 
-  default(value: T): ZodSchema<T> {
+  default(value: T): BaseSchema<T> {
     const inner = this
     return new (class extends BaseSchema<T> {
       _parse(input: unknown, path: (string | number)[]): T {
@@ -286,6 +279,8 @@ export const z = {
   effects,
   ZodError,
 }
+
+export type ZodSchema<T> = BaseSchema<T>
 
 export type infer<T extends ZodSchema<any>> = T extends ZodSchema<infer U> ? U : never
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -35,7 +35,12 @@ export function middleware(req: NextRequest) {
 
   try {
     const decoded = Buffer.from(header.slice(6), 'base64').toString()
-    const [name, password] = decoded.split(':')
+    const separatorIndex = decoded.indexOf(':')
+    if (separatorIndex === -1) {
+      return unauthorized()
+    }
+    const name = decoded.slice(0, separatorIndex)
+    const password = decoded.slice(separatorIndex + 1)
     if (name !== user || password !== pass) {
       return unauthorized()
     }

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,69 +1,47 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server'
 
-const REALM = 'Palestine CMS';
+const REALM = 'Palestine CMS'
 
 export const config = {
-  matcher: ['/admin/:path*', '/api/cms/:path*'],
-};
+  matcher: ['/admin/:path*', '/api/admin/:path*'],
+}
 
-function unauthorized() {
-  return new Response('Unauthorized', {
+const unauthorized = () =>
+  new Response('Unauthorized', {
     status: 401,
     headers: { 'WWW-Authenticate': `Basic realm="${REALM}"` },
-  });
-}
-
-function missingAuthConfig(message: string) {
-  return new Response(message, { status: 500 });
-}
+  })
 
 export function middleware(req: NextRequest) {
   if (req.method === 'OPTIONS') {
-    return NextResponse.next();
+    return NextResponse.next()
   }
 
-  const user =
-    process.env.BASIC_AUTH_USER ??
-    process.env.BASIC_AUTH_USERS ??
-    '';
-  const pass =
-    process.env.BASIC_AUTH_PASS ??
-    process.env.BASIC_AUTH_PASSWORD ??
-    '';
-  const mode = process.env.CMS_MODE ?? '';
+  const mode = (process.env.CMS_AUTH_MODE ?? 'oauth').toLowerCase()
+  if (mode !== 'token') {
+    return NextResponse.next()
+  }
 
+  const user = process.env.BASIC_AUTH_USER
+  const pass = process.env.BASIC_AUTH_PASS
   if (!user || !pass) {
-    return missingAuthConfig('CMS basic auth is not configured');
+    return NextResponse.next()
   }
 
-  if (!mode) {
-    return missingAuthConfig('CMS authentication mode is not configured');
-  }
-
-  const normalizedMode = mode.toLowerCase();
-  if (normalizedMode !== 'oauth' && normalizedMode !== 'token') {
-    return missingAuthConfig('CMS authentication mode is invalid');
-  }
-
-  const auth = req.headers.get('authorization') || '';
-  if (!auth.startsWith('Basic ')) {
-    return unauthorized();
+  const header = req.headers.get('authorization')
+  if (!header || !header.startsWith('Basic ')) {
+    return unauthorized()
   }
 
   try {
-    const decoded = atob(auth.slice(6));
-    const separatorIndex = decoded.indexOf(':');
-    if (separatorIndex < 0) {
-      return unauthorized();
-    }
-    const name = decoded.slice(0, separatorIndex);
-    const pwd = decoded.slice(separatorIndex + 1);
-    if (name !== user || pwd !== pass) {
-      return unauthorized();
+    const decoded = Buffer.from(header.slice(6), 'base64').toString()
+    const [name, password] = decoded.split(':')
+    if (name !== user || password !== pass) {
+      return unauthorized()
     }
   } catch {
-    return unauthorized();
+    return unauthorized()
   }
 
-  return NextResponse.next();
+  return NextResponse.next()
 }

--- a/tests/unit/admin/save-route.test.ts
+++ b/tests/unit/admin/save-route.test.ts
@@ -1,0 +1,69 @@
+import { NextRequest } from 'next/server'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const authMock = vi.hoisted(() => ({
+  ensureAuth: vi.fn(() => ({ ok: true, mode: 'token', session: null })),
+}))
+
+vi.mock('@/lib/api/auth', () => authMock)
+
+const csrfMock = vi.hoisted(() => ({
+  requireCsrfToken: vi.fn(() => null),
+}))
+
+vi.mock('@/lib/api/csrf', () => csrfMock)
+
+const githubMocks = vi.hoisted(() => ({
+  getOctokitForRequest: vi.fn(() => ({})),
+  ensureBranch: vi.fn(),
+  getFile: vi.fn(() => Promise.resolve(null)),
+  putFile: vi.fn(() => Promise.resolve({ commit: { sha: 'abc123' } })),
+  findPullRequestByBranch: vi.fn(() => Promise.resolve(undefined)),
+  createPullRequest: vi.fn(),
+  getRawFileUrl: vi.fn(() => 'https://raw.githubusercontent.com/test/repo/file'),
+  resolveCommitAuthor: vi.fn(() => ({ name: 'Bot', email: 'bot@example.com' })),
+  updatePullRequestBody: vi.fn(),
+}))
+
+vi.mock('@/lib/github', () => githubMocks)
+
+import { POST } from '@/app/api/admin/save/route'
+
+describe('POST /api/admin/save', () => {
+  beforeEach(() => {
+    process.env.CMS_GITHUB_REPO = 'owner/repo'
+    process.env.CMS_GITHUB_BRANCH = 'main'
+    Object.values(authMock).forEach((mock) => (mock as any).mock?.clear?.())
+    Object.values(csrfMock).forEach((mock) => (mock as any).mock?.clear?.())
+    Object.values(githubMocks).forEach((mock) => (mock as any).mock?.clear?.())
+  })
+
+  afterEach(() => {
+    delete process.env.CMS_GITHUB_REPO
+    delete process.env.CMS_GITHUB_BRANCH
+  })
+
+  it('publishes markdown entry to main branch', async () => {
+    const body = {
+      collection: 'chapters_en',
+      frontmatter: { title: 'Hello', slug: 'hello' },
+      body: 'Body',
+      workflow: 'publish',
+      message: '',
+    }
+    const request = new NextRequest('http://localhost/api/admin/save', {
+      method: 'POST',
+      body: JSON.stringify(body),
+      headers: { 'Content-Type': 'application/json' },
+    })
+    const response = await POST(request)
+    expect(response.status).toBe(200)
+    const json = await response.json()
+    expect(json.commitSha).toBe('abc123')
+    expect(json.urlToRaw).toBe('https://raw.githubusercontent.com/test/repo/file')
+    expect(githubMocks.putFile).toHaveBeenCalled()
+    expect(csrfMock.requireCsrfToken).toHaveBeenCalled()
+    const [, , , commitMessage] = (githubMocks.putFile as any).mock.calls[0]
+    expect(commitMessage).toContain('Publish')
+  })
+})

--- a/tests/unit/collections.test.ts
+++ b/tests/unit/collections.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { collections, getCollection } from '@/lib/collections'
+
+describe('collections schema', () => {
+  it('includes expected collections', () => {
+    const ids = collections.map((collection) => collection.id)
+    expect(ids).toContain('chapters_en')
+    expect(ids).toContain('timeline_data')
+  })
+
+  it('validates chapter frontmatter', () => {
+    const collection = getCollection('chapters_en')
+    expect(collection).toBeDefined()
+    const result = collection!.schema.safeParse({
+      title: 'Test Title',
+      slug: 'test-slug',
+      date: '2024-01-01',
+      tags: ['history'],
+      summary: 'Summary',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects invalid timeline data without slug', () => {
+    const collection = getCollection('timeline_data')
+    expect(collection).toBeDefined()
+    const result = collection!.schema.safeParse({
+      title: 'Entry',
+      events: [{ id: '1', label: 'Event' }],
+    })
+    expect(result.success).toBe(false)
+  })
+})

--- a/tests/unit/md.test.ts
+++ b/tests/unit/md.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { parseMarkdown, serializeMarkdown } from '@/lib/md'
+
+describe('markdown serialization', () => {
+  it('round trips frontmatter and body', () => {
+    const original = `---\ntitle: Test\nslug: test\n---\n\nHello world\n`
+    const parsed = parseMarkdown(original)
+    expect(parsed.frontmatter.title).toBe('Test')
+    expect(parsed.body.trim()).toBe('Hello world')
+    const serialized = serializeMarkdown(parsed)
+    expect(serialized).toContain('title: Test')
+    expect(serialized).toContain('Hello world')
+  })
+})


### PR DESCRIPTION
## Summary
- replace the Decap integration with a custom admin SPA at /admin backed by GitHub API helpers
- implement authenticated route handlers for listing, editing, saving, deleting, and uploading CMS content
- add lightweight zod-style validation utilities, GitHub helper wrappers, and Playwright-ready UI components with image uploads and draft/publish workflows
- document the new environment variables and setup flow in README and provide unit tests for schemas, markdown serialization, and save handler

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_b_690a5822abfc832eabbfb15b963d9f9a