### PR TITLE
feat: align CMS content and add translation workflow

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,9 +1,10 @@
 'use client'
 
 import { useEffect, useMemo, useRef, useState } from 'react'
+import YAML from 'yaml'
 import CollectionSwitcher, { type CollectionSummary } from '@/components/CollectionSwitcher'
 import EntryList, { type Entry } from '@/components/EntryList'
-import Editor, { type EditorState, type JsonEditorState, type MarkdownEditorState } from '@/components/Editor'
+import Editor, { type EditorState, type MarkdownEditorState, type StructuredEditorState } from '@/components/Editor'
 
 type Session = {
   name?: string
@@ -26,6 +27,8 @@ const fetchJSON = async <T,>(url: string, init?: RequestInit): Promise<T> => {
   return response.json() as Promise<T>
 }
 
+const addArabicSuffix = (value: string) => (value.endsWith('.ar') ? value : `${value}.ar`)
+
 const AdminPage = () => {
   const [authMode, setAuthMode] = useState<'oauth' | 'token' | null>(null)
   const [requiresLogin, setRequiresLogin] = useState(false)
@@ -44,6 +47,7 @@ const AdminPage = () => {
   const [unsaved, setUnsaved] = useState(false)
   const [isNew, setIsNew] = useState(false)
   const [toasts, setToasts] = useState<Toast[]>([])
+  const [translating, setTranslating] = useState(false)
   const slugRef = useRef<string | null>(null)
 
   const pushToast = (type: 'success' | 'error', messageText: string) => {
@@ -140,20 +144,26 @@ const AdminPage = () => {
       const data = await fetchJSON<{
         frontmatter?: Record<string, unknown>
         body?: string
-        data?: Record<string, unknown>
+        data?: unknown
+        path?: string
       }>(`/api/admin/item?${query.toString()}`)
       const collection = collections.find((item) => item.id === selectedCollection)
-      if (collection?.format === 'json') {
-        const jsonState: JsonEditorState = {
-          format: 'json',
-          json: JSON.stringify(data.data ?? data.frontmatter ?? {}, null, 2),
+      if (collection?.format === 'json' || collection?.format === 'yaml') {
+        const textValue = collection.format === 'json'
+          ? JSON.stringify(data.data ?? data.frontmatter ?? {}, null, 2)
+          : YAML.stringify(data.data ?? data.frontmatter ?? {})
+        const structuredState: StructuredEditorState = {
+          format: collection.format,
+          text: textValue,
+          path: data.path ?? null,
         }
-        setEditorState(jsonState)
+        setEditorState(structuredState)
       } else {
         const mdState: MarkdownEditorState = {
           format: 'markdown',
           frontmatter: data.frontmatter ?? {},
           body: data.body ?? '',
+          path: data.path ?? null,
         }
         setEditorState(mdState)
       }
@@ -188,16 +198,21 @@ const AdminPage = () => {
     setWorkflow(collection.defaultWorkflow)
     setMessage('')
     slugRef.current = null
-    if (collection.format === 'json') {
+    if (collection.format === 'json' || collection.format === 'yaml') {
+      const initialText = collection.format === 'json'
+        ? JSON.stringify({ slug: '', title: '' }, null, 2)
+        : `id: ""\ntitle: ""\n`
       setEditorState({
-        format: 'json',
-        json: JSON.stringify({ slug: '', title: '' }, null, 2),
+        format: collection.format,
+        text: initialText,
+        path: null,
       })
     } else {
       setEditorState({
         format: 'markdown',
         frontmatter: { title: '', [collection.slugField]: '' },
         body: '',
+        path: null,
       })
     }
     setUnsaved(false)
@@ -241,6 +256,10 @@ const AdminPage = () => {
   }
 
   const resolveSlug = (state: EditorState, collection: CollectionSummary) => {
+    const existing = selectedSlug ?? slugRef.current
+    if (existing) {
+      return existing
+    }
     if (state.format === 'markdown') {
       const value = state.frontmatter[collection.slugField]
       if (typeof value === 'string' && value) {
@@ -250,13 +269,18 @@ const AdminPage = () => {
       return typeof title === 'string' ? title : ''
     }
     try {
-      const parsed = JSON.parse(state.json)
-      const value = parsed?.[collection.slugField]
-      if (typeof value === 'string') {
-        return value
+      const parsed = state.format === 'json' ? JSON.parse(state.text) : YAML.parse(state.text)
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        const value = (parsed as Record<string, unknown>)[collection.slugField]
+        if (typeof value === 'string' && value) {
+          return value
+        }
+        const title = (parsed as Record<string, unknown>).title
+        if (typeof title === 'string' && title) {
+          return title
+        }
       }
-      const title = parsed?.title
-      return typeof title === 'string' ? title : ''
+      return ''
     } catch {
       return ''
     }
@@ -272,15 +296,22 @@ const AdminPage = () => {
     }
     let frontmatter: Record<string, unknown> | undefined
     let body: string | undefined
-    let data: Record<string, unknown> | undefined
+    let data: unknown
     if (editorState.format === 'markdown') {
       frontmatter = editorState.frontmatter
       body = editorState.body
-    } else {
+    } else if (editorState.format === 'json') {
       try {
-        data = JSON.parse(editorState.json)
+        data = JSON.parse(editorState.text)
       } catch {
         pushToast('error', 'Invalid JSON payload')
+        return
+      }
+    } else {
+      try {
+        data = YAML.parse(editorState.text) ?? {}
+      } catch {
+        pushToast('error', 'Invalid YAML payload')
         return
       }
     }
@@ -293,9 +324,13 @@ const AdminPage = () => {
         workflow,
         message: message.trim(),
       }
+      const originalSlugValue = selectedSlug ?? slugRef.current
+      if (originalSlugValue) {
+        payload.originalSlug = originalSlugValue
+      }
       if (frontmatter) payload.frontmatter = frontmatter
       if (body !== undefined) payload.body = body
-      if (data) payload.data = data
+      if (data !== undefined) payload.data = data
       const headers: Record<string, string> = { 'Content-Type': 'application/json' }
       if (csrfToken) {
         headers['x-csrf-token'] = csrfToken
@@ -315,7 +350,9 @@ const AdminPage = () => {
       } else {
         pushToast('success', 'Entry saved to main branch')
       }
-      const nextSlug = slugValue || slugRef.current
+      const nextSlug = typeof json.slug === 'string' && json.slug.length > 0
+        ? json.slug
+        : slugValue || slugRef.current
       if (nextSlug) {
         setSelectedSlug(nextSlug)
         slugRef.current = nextSlug
@@ -331,6 +368,109 @@ const AdminPage = () => {
       pushToast('error', (error as Error).message)
     } finally {
       setSaving(false)
+    }
+  }
+
+  const handleTranslate = async () => {
+    if (!editorState || editorState.format !== 'markdown') {
+      return
+    }
+    const collection = collections.find((item) => item.id === selectedCollection)
+    if (collection?.id !== 'chapters_en') {
+      return
+    }
+    const englishSlug = selectedSlug ?? slugRef.current
+    if (!englishSlug) {
+      pushToast('error', 'Save the English chapter before translating.')
+      return
+    }
+    const translateValue = async (text: string) => {
+      if (!text.trim()) {
+        return text
+      }
+      const response = await fetch('/api/admin/translate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text, source: 'en', target: 'ar' }),
+      })
+      if (!response.ok) {
+        throw new Error('Translate failed')
+      }
+      const result = await response.json()
+      return typeof result.translated === 'string' ? result.translated : text
+    }
+    setTranslating(true)
+    try {
+      let translationErrored = false
+      const safeTranslate = async (input: string) => {
+        if (!input.trim()) return input
+        try {
+          return await translateValue(input)
+        } catch {
+          if (!translationErrored) {
+            pushToast('error', 'Translation service unavailable; using original text.')
+            translationErrored = true
+          }
+          return input
+        }
+      }
+
+      const originalFrontmatter = editorState.frontmatter
+      const translatedTitle = typeof originalFrontmatter.title === 'string'
+        ? await safeTranslate(originalFrontmatter.title)
+        : ''
+      const translatedSummary = typeof originalFrontmatter.summary === 'string'
+        ? await safeTranslate(originalFrontmatter.summary)
+        : undefined
+      const translatedBody = await safeTranslate(editorState.body)
+
+      const translatedFrontmatter: Record<string, unknown> = {
+        ...originalFrontmatter,
+        title: translatedTitle,
+        language: 'ar',
+      }
+      if (translatedSummary !== undefined) {
+        translatedFrontmatter.summary = translatedSummary
+      }
+
+      const arabicSlug = addArabicSuffix(englishSlug)
+      const payload: Record<string, unknown> = {
+        collection: 'chapters_ar',
+        slug: arabicSlug,
+        originalSlug: arabicSlug,
+        workflow: 'draft',
+        frontmatter: translatedFrontmatter,
+        body: translatedBody,
+      }
+      if (translationErrored) {
+        payload.message = 'Translated with partial results'
+      }
+      const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+      if (csrfToken) {
+        headers['x-csrf-token'] = csrfToken
+      }
+      const response = await fetch('/api/admin/save', {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(payload),
+      })
+      if (!response.ok) {
+        const error = await response.json().catch(() => ({ error: 'Unable to save Arabic translation' }))
+        throw new Error(error.error ?? 'Unable to save Arabic translation')
+      }
+      const result = await response.json()
+      if (result.prUrl) {
+        pushToast('success', `Arabic draft ready: ${result.prUrl}`)
+      } else {
+        pushToast('success', 'Arabic translation saved')
+      }
+      if (selectedCollection === 'chapters_ar') {
+        await loadEntries('chapters_ar')
+      }
+    } catch (error) {
+      pushToast('error', (error as Error).message)
+    } finally {
+      setTranslating(false)
     }
   }
 
@@ -478,6 +618,9 @@ const AdminPage = () => {
               onMessageChange={setMessage}
               onError={(text) => pushToast('error', text)}
               csrfToken={csrfToken}
+              canTranslate={collection?.id === 'chapters_en' && editorState?.format === 'markdown'}
+              translating={translating}
+              onTranslate={handleTranslate}
             />
           </div>
         </section>

--- a/app/api/admin/item/route.ts
+++ b/app/api/admin/item/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { ensureAuth } from '@/lib/api/auth'
 import { requireCsrfToken } from '@/lib/api/csrf'
-import { getCollection } from '@/lib/collections'
-import { readEntry, resolveCollectionPath } from '@/lib/content'
+import { getCollection, getEntryPath } from '@/lib/collections'
+import { readEntry } from '@/lib/content'
 import {
   createPullRequest,
   deleteFile,
@@ -91,7 +91,9 @@ export const DELETE = async (req: NextRequest) => {
   const branchName = branchWorkflow === 'draft' ? `cms/${slug}` : undefined
   const client = getOctokitForRequest(req)
   const author = resolveCommitAuthor(auth.mode === 'oauth' ? auth.session : undefined)
-  const path = await resolveCollectionPath(client, collection, slug, branchName)
+  const path =
+    (await collection.resolvePath?.(client, slug, { branch: branchName })) ??
+    (collection.singleFile ?? getEntryPath(collection, slug))
   try {
     if (branchName) {
       await ensureBranch(client, branchName)

--- a/app/api/admin/item/route.ts
+++ b/app/api/admin/item/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { ensureAuth } from '@/lib/api/auth'
 import { requireCsrfToken } from '@/lib/api/csrf'
-import { getCollection, getEntryPath } from '@/lib/collections'
-import { readEntry } from '@/lib/content'
+import { getCollection } from '@/lib/collections'
+import { readEntry, resolveCollectionPath } from '@/lib/content'
 import {
   createPullRequest,
   deleteFile,
@@ -91,7 +91,7 @@ export const DELETE = async (req: NextRequest) => {
   const branchName = branchWorkflow === 'draft' ? `cms/${slug}` : undefined
   const client = getOctokitForRequest(req)
   const author = resolveCommitAuthor(auth.mode === 'oauth' ? auth.session : undefined)
-  const path = getEntryPath(collection, slug)
+  const path = await resolveCollectionPath(client, collection, slug, branchName)
   try {
     if (branchName) {
       await ensureBranch(client, branchName)

--- a/app/api/admin/translate/route.ts
+++ b/app/api/admin/translate/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { ensureAuth } from '@/lib/api/auth'
+
+const TRANSLATE_URL = 'https://libretranslate.com/translate'
+
+type TranslateBody = {
+  text?: string
+  source?: string
+  target?: string
+}
+
+export const POST = async (req: NextRequest) => {
+  const auth = ensureAuth(req)
+  if (!auth.ok) {
+    return auth.response
+  }
+  let payload: TranslateBody
+  try {
+    payload = await req.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+  const text = typeof payload.text === 'string' ? payload.text : ''
+  if (!text) {
+    return NextResponse.json({ translated: '' })
+  }
+  const source = typeof payload.source === 'string' && payload.source ? payload.source : 'en'
+  const target = typeof payload.target === 'string' && payload.target ? payload.target : 'ar'
+  try {
+    const response = await fetch(TRANSLATE_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ q: text, source, target, format: 'text' }),
+    })
+    if (!response.ok) {
+      throw new Error('Translation provider error')
+    }
+    const result = await response.json()
+    const translated =
+      typeof result.translatedText === 'string'
+        ? result.translatedText
+        : typeof result.translated === 'string'
+          ? result.translated
+          : text
+    return NextResponse.json({ translated })
+  } catch (error) {
+    console.error('Translation fallback', error)
+    return NextResponse.json({ translated: text })
+  }
+}

--- a/components/CollectionSwitcher.tsx
+++ b/components/CollectionSwitcher.tsx
@@ -3,7 +3,7 @@
 export type CollectionSummary = {
   id: string
   label: string
-  format: 'markdown' | 'json'
+  format: 'markdown' | 'json' | 'yaml'
   defaultWorkflow: 'draft' | 'publish'
   slugField: string
   fields: { name: string; type: string; required?: boolean }[]

--- a/components/Editor.tsx
+++ b/components/Editor.tsx
@@ -8,14 +8,16 @@ export type MarkdownEditorState = {
   format: 'markdown'
   frontmatter: Record<string, unknown>
   body: string
+  path: string | null
 }
 
-export type JsonEditorState = {
-  format: 'json'
-  json: string
+export type StructuredEditorState = {
+  format: 'json' | 'yaml'
+  text: string
+  path: string | null
 }
 
-export type EditorState = MarkdownEditorState | JsonEditorState
+export type EditorState = MarkdownEditorState | StructuredEditorState
 
 type Props = {
   collection: CollectionSummary | null
@@ -31,6 +33,9 @@ type Props = {
   onMessageChange: (value: string) => void
   onError: (message: string) => void
   csrfToken: string | null
+  canTranslate?: boolean
+  translating?: boolean
+  onTranslate?: () => void
 }
 
 const fieldValue = (frontmatter: Record<string, unknown>, key: string) => {
@@ -52,6 +57,9 @@ const Editor = ({
   onMessageChange,
   onError,
   csrfToken,
+  canTranslate = false,
+  translating = false,
+  onTranslate,
 }: Props) => {
   useEffect(() => {
     const handleKey = (event: KeyboardEvent) => {
@@ -187,6 +195,11 @@ const Editor = ({
         {unsaved ? <span className="text-xs font-medium uppercase tracking-wide text-amber-600">Unsaved changes</span> : null}
       </div>
 
+      <div className="rounded border border-zinc-200 bg-zinc-50 px-3 py-2 text-xs text-zinc-600">
+        <span className="font-medium text-zinc-700">Path:</span>{' '}
+        {state.path ?? 'Not saved yet'}
+      </div>
+
       {state.format === 'markdown' ? (
         <div className="grid gap-4 md:grid-cols-2">
           <div className="flex flex-col gap-3">
@@ -219,10 +232,10 @@ const Editor = ({
         </div>
       ) : (
         <div className="flex flex-col gap-2">
-          <span className="text-sm font-medium text-zinc-700">JSON</span>
+          <span className="text-sm font-medium text-zinc-700">{state.format.toUpperCase()}</span>
           <textarea
-            value={state.json}
-            onChange={(event) => onChange({ ...state, json: event.target.value })}
+            value={state.text}
+            onChange={(event) => onChange({ ...state, text: event.target.value })}
             className="h-72 w-full rounded border border-zinc-300 px-3 py-2 text-sm font-mono focus:border-black focus:outline-none"
           />
         </div>
@@ -239,6 +252,18 @@ const Editor = ({
         >
           {saving ? 'Saving…' : 'Save'}
         </button>
+        {canTranslate ? (
+          <button
+            type="button"
+            onClick={onTranslate}
+            disabled={translating}
+            className={`rounded border border-emerald-600 px-4 py-2 text-sm font-medium transition ${
+              translating ? 'bg-emerald-100 text-emerald-500' : 'text-emerald-700 hover:bg-emerald-600 hover:text-white'
+            }`}
+          >
+            {translating ? 'Translating…' : 'Translate to Arabic'}
+          </button>
+        ) : null}
         <button
           type="button"
           onClick={onDelete}

--- a/components/EntryList.tsx
+++ b/components/EntryList.tsx
@@ -56,7 +56,14 @@ const EntryList = ({ entries, selected, onSelect, onCreate, search, onSearch }: 
                     selected === entry.slug ? 'bg-black text-white' : 'hover:bg-zinc-100'
                   }`}
                 >
-                  <div className="text-sm font-medium">{entry.title}</div>
+                  <div className="flex items-center gap-2 text-sm font-medium">
+                    <span>{entry.title}</span>
+                    {entry.slug.endsWith('.ar') ? (
+                      <span className={`rounded px-1 text-xs font-semibold ${selected === entry.slug ? 'bg-white text-black' : 'bg-zinc-200 text-zinc-700'}`}>
+                        AR
+                      </span>
+                    ) : null}
+                  </div>
                   <div className={`text-xs ${selected === entry.slug ? 'text-zinc-200' : 'text-zinc-500'}`}>
                     {entry.slug}
                   </div>

--- a/lib/slugs.ts
+++ b/lib/slugs.ts
@@ -1,4 +1,6 @@
 const ASCII_DIACRITICS = /[\u0300-\u036f]/g
+const NUMERIC_PREFIX = /^(\d{3})-/
+const AR_SUFFIX = /\.ar$/
 
 export const slugify = (value: string) => {
   return value
@@ -14,3 +16,22 @@ export const slugify = (value: string) => {
 export const sanitizeFilename = (value: string) => {
   return value.replace(/[^a-zA-Z0-9._-]/g, '')
 }
+
+export const hasNumericPrefix = (value: string) => NUMERIC_PREFIX.test(value)
+
+export const extractNumericPrefix = (value: string) => {
+  const match = value.match(NUMERIC_PREFIX)
+  if (!match) {
+    return null
+  }
+  const numeric = Number.parseInt(match[1] ?? '', 10)
+  return Number.isNaN(numeric) ? null : numeric
+}
+
+export const stripNumericPrefix = (value: string) => value.replace(NUMERIC_PREFIX, '')
+
+export const isArabicSlug = (value: string) => AR_SUFFIX.test(value)
+
+export const ensureArabicSuffix = (value: string) => (isArabicSlug(value) ? value : `${value}.ar`)
+
+export const stripArabicSuffix = (value: string) => value.replace(AR_SUFFIX, '')

--- a/lib/zod.ts
+++ b/lib/zod.ts
@@ -254,6 +254,12 @@ class ZodEffects<I, O> extends BaseSchema<O> {
   }
 }
 
+class ZodAny extends BaseSchema<any> {
+  _parse(input: unknown): any {
+    return input
+  }
+}
+
 const string = () => new ZodString()
 const boolean = () => new ZodBoolean()
 const number = () => new ZodNumber()
@@ -265,6 +271,7 @@ const object = <T extends Record<string, any>>(shape: { [K in keyof T]: BaseSche
   new ZodObject(shape)
 const union = <T>(options: BaseSchema<any>[]) => new ZodUnion<T>(options)
 const effects = <I, O>(schema: BaseSchema<I>, transform: (input: I) => O) => new ZodEffects(schema, transform)
+const anyValue = () => new ZodAny()
 
 export const z = {
   string,
@@ -277,6 +284,7 @@ export const z = {
   record,
   union,
   effects,
+  any: anyValue,
   ZodError,
 }
 

--- a/tests/unit/admin/save-route.test.ts
+++ b/tests/unit/admin/save-route.test.ts
@@ -13,33 +13,21 @@ const csrfMock = vi.hoisted(() => ({
 
 vi.mock('@/lib/api/csrf', () => csrfMock)
 
-const contentMocks = vi.hoisted(() => ({
-  resolveCollectionPath: vi.fn((_, __, slug: string) => Promise.resolve(`content/chapters/${slug}.mdx`)),
-  slugFromPath: vi.fn((_, path: string) => {
-    const base = path.split('/').pop() ?? ''
-    return base.replace(/\.mdx$/, '')
-  }),
-}))
+type DirectoryEntry = { name: string; path: string; sha: string; type: 'file' }
 
-vi.mock('@/lib/content', async () => {
-  const actual = await vi.importActual<typeof import('@/lib/content')>('@/lib/content')
-  return {
-    ...actual,
-    resolveCollectionPath: contentMocks.resolveCollectionPath,
-    slugFromPath: contentMocks.slugFromPath,
-  }
-})
+const cloneEntries = (entries: DirectoryEntry[]) => entries.map((entry) => ({ ...entry }))
 
 const githubMocks = vi.hoisted(() => ({
   getOctokitForRequest: vi.fn(() => ({})),
   ensureBranch: vi.fn(),
-  getFile: vi.fn(() => Promise.resolve(null)),
-  putFile: vi.fn(() => Promise.resolve({ commit: { sha: 'abc123' } })),
+  getFile: vi.fn(),
+  putFile: vi.fn(),
   findPullRequestByBranch: vi.fn(() => Promise.resolve(undefined)),
   createPullRequest: vi.fn(),
   getRawFileUrl: vi.fn(() => 'https://raw.githubusercontent.com/test/repo/file'),
   resolveCommitAuthor: vi.fn(() => ({ name: 'Bot', email: 'bot@example.com' })),
   updatePullRequestBody: vi.fn(),
+  listDirectory: vi.fn(),
 }))
 
 vi.mock('@/lib/github', () => githubMocks)
@@ -47,12 +35,76 @@ vi.mock('@/lib/github', () => githubMocks)
 import { POST } from '@/app/api/admin/save/route'
 
 describe('POST /api/admin/save', () => {
+  const branchState: Record<string, DirectoryEntry[]> = {}
+  let commitCounter = 0
+
+  const ensureEntries = (branch?: string) => {
+    const key = branch ?? 'main'
+    if (!branchState[key]) {
+      branchState[key] = cloneEntries(branchState.main ?? [])
+    }
+    return branchState[key]
+  }
+
   beforeEach(() => {
     process.env.CMS_GITHUB_REPO = 'owner/repo'
     process.env.CMS_GITHUB_BRANCH = 'main'
     Object.values(authMock).forEach((mock) => (mock as any).mock?.clear?.())
     Object.values(csrfMock).forEach((mock) => (mock as any).mock?.clear?.())
     Object.values(githubMocks).forEach((mock) => (mock as any).mock?.clear?.())
+    githubMocks.putFile.mockClear()
+    githubMocks.listDirectory.mockClear()
+    githubMocks.getFile.mockClear()
+    for (const key of Object.keys(branchState)) {
+      delete branchState[key]
+    }
+    branchState.main = cloneEntries([
+      {
+        name: '001-prologue.mdx',
+        path: 'content/chapters/001-prologue.mdx',
+        sha: 'sha-main-en',
+        type: 'file',
+      },
+      {
+        name: '001-prologue.ar.mdx',
+        path: 'content/chapters/001-prologue.ar.mdx',
+        sha: 'sha-main-ar',
+        type: 'file',
+      },
+    ])
+    commitCounter = 0
+
+    githubMocks.listDirectory.mockImplementation(async (_client, directory: string, branch?: string) => {
+      if (directory !== 'content/chapters') {
+        return []
+      }
+      return cloneEntries(ensureEntries(branch))
+    })
+
+    githubMocks.getFile.mockImplementation(async (_client, targetPath: string, branch?: string) => {
+      const entries = ensureEntries(branch)
+      const existing = entries.find((entry) => entry.path === targetPath)
+      if (!existing) {
+        throw new Error('Not Found')
+      }
+      return { sha: existing.sha, content: '', encoding: 'base64', path: existing.path }
+    })
+
+    githubMocks.putFile.mockImplementation(
+      async (_client, targetPath: string, _content: string, _message: string, branch?: string) => {
+        const entries = ensureEntries(branch)
+        const name = targetPath.split('/').pop() ?? targetPath
+        const nextSha = `sha-${++commitCounter}`
+        const updated: DirectoryEntry = { name, path: targetPath, sha: nextSha, type: 'file' }
+        const index = entries.findIndex((entry) => entry.name === name)
+        if (index >= 0) {
+          entries[index] = updated
+        } else {
+          entries.push(updated)
+        }
+        return { commit: { sha: nextSha } }
+      },
+    )
   })
 
   afterEach(() => {
@@ -76,13 +128,12 @@ describe('POST /api/admin/save', () => {
     const response = await POST(request)
     expect(response.status).toBe(200)
     const json = await response.json()
-    expect(json.commitSha).toBe('abc123')
+    expect(json.commitSha).toBe('sha-1')
     expect(json.urlToRaw).toBe('https://raw.githubusercontent.com/test/repo/file')
-    expect(json.slug).toBe('hello')
+    expect(json.slug).toBe('002-hello')
     expect(githubMocks.putFile).toHaveBeenCalled()
-    expect(contentMocks.resolveCollectionPath).toHaveBeenCalledWith(expect.any(Object), expect.any(Object), 'hello', undefined)
     const [, pathArg] = (githubMocks.putFile as any).mock.calls[0]
-    expect(pathArg).toBe('content/chapters/hello.mdx')
+    expect(pathArg).toBe('content/chapters/002-hello.mdx')
     expect(csrfMock.requireCsrfToken).toHaveBeenCalled()
     const [, , , commitMessage] = (githubMocks.putFile as any).mock.calls[0]
     expect(commitMessage).toContain('Publish')
@@ -104,11 +155,71 @@ describe('POST /api/admin/save', () => {
       headers: { 'Content-Type': 'application/json' },
     })
     await POST(request)
-    expect(contentMocks.resolveCollectionPath).toHaveBeenCalledWith(
-      expect.any(Object),
-      expect.any(Object),
-      '001-prologue',
-      undefined,
+    const lastCall = githubMocks.putFile.mock.calls.at(-1)
+    expect(lastCall?.[1]).toBe('content/chapters/001-prologue.mdx')
+  })
+
+  it('updates the same file when saving a draft multiple times', async () => {
+    const body = {
+      collection: 'chapters_en',
+      slug: 'hello',
+      frontmatter: { title: 'Hello', slug: 'hello', language: 'en' },
+      body: 'Body',
+      workflow: 'draft',
+      message: '',
+    }
+    const request = (payload: Record<string, unknown>) =>
+      new NextRequest('http://localhost/api/admin/save', {
+        method: 'POST',
+        body: JSON.stringify(payload),
+        headers: { 'Content-Type': 'application/json' },
+      })
+
+    await POST(request(body))
+    const firstPath = (githubMocks.putFile as any).mock.calls[0][1]
+    expect(firstPath).toBe('content/chapters/002-hello.mdx')
+
+    githubMocks.putFile.mockClear()
+    githubMocks.findPullRequestByBranch.mockResolvedValue({ html_url: 'https://example.com', number: 1 } as any)
+
+    await POST(
+      request({
+        ...body,
+        originalSlug: '002-hello',
+      }),
     )
+    const secondPath = (githubMocks.putFile as any).mock.calls[0][1]
+    expect(secondPath).toBe('content/chapters/002-hello.mdx')
+  })
+
+  it('updates the Arabic sibling in place on a draft branch', async () => {
+    const body = {
+      collection: 'chapters_ar',
+      slug: '001-prologue.ar',
+      originalSlug: '001-prologue.ar',
+      frontmatter: { title: 'مرحبا', slug: 'prologue', language: 'ar' },
+      body: 'Body',
+      workflow: 'draft',
+      message: '',
+    }
+    const makeRequest = () =>
+      new NextRequest('http://localhost/api/admin/save', {
+        method: 'POST',
+        body: JSON.stringify(body),
+        headers: { 'Content-Type': 'application/json' },
+      })
+
+    const firstResponse = await POST(makeRequest())
+    expect(firstResponse.status).toBe(200)
+    const firstCall = githubMocks.putFile.mock.calls.at(-1)
+    expect(firstCall?.[1]).toBe('content/chapters/001-prologue.ar.mdx')
+
+    const initialCallCount = githubMocks.putFile.mock.calls.length
+
+    const secondResponse = await POST(makeRequest())
+    expect(secondResponse.status).toBe(200)
+    expect(githubMocks.putFile.mock.calls.length).toBe(initialCallCount + 1)
+    const secondCall = githubMocks.putFile.mock.calls.at(-1)
+    expect(secondCall?.[1]).toBe('content/chapters/001-prologue.ar.mdx')
   })
 })

--- a/tests/unit/collections.test.ts
+++ b/tests/unit/collections.test.ts
@@ -5,7 +5,10 @@ describe('collections schema', () => {
   it('includes expected collections', () => {
     const ids = collections.map((collection) => collection.id)
     expect(ids).toContain('chapters_en')
-    expect(ids).toContain('timeline_data')
+    expect(ids).toContain('chapters_ar')
+    expect(ids).toContain('timeline')
+    expect(ids).toContain('bibliography')
+    expect(ids).toContain('gazetteer')
   })
 
   it('validates chapter frontmatter', () => {
@@ -14,6 +17,7 @@ describe('collections schema', () => {
     const result = collection!.schema.safeParse({
       title: 'Test Title',
       slug: 'test-slug',
+      language: 'en',
       date: '2024-01-01',
       tags: ['history'],
       summary: 'Summary',
@@ -21,13 +25,29 @@ describe('collections schema', () => {
     expect(result.success).toBe(true)
   })
 
-  it('rejects invalid timeline data without slug', () => {
-    const collection = getCollection('timeline_data')
+  it('filters Arabic filenames correctly', () => {
+    const english = getCollection('chapters_en')
+    const arabic = getCollection('chapters_ar')
+    expect(english?.filenameFilter?.('001-prologue.mdx')).toBe(true)
+    expect(english?.filenameFilter?.('001-prologue.ar.mdx')).toBe(false)
+    expect(arabic?.filenameFilter?.('001-prologue.ar.mdx')).toBe(true)
+    expect(arabic?.filenameFilter?.('001-prologue.mdx')).toBe(false)
+  })
+
+  it('accepts timeline yaml structure', () => {
+    const collection = getCollection('timeline')
     expect(collection).toBeDefined()
     const result = collection!.schema.safeParse({
-      title: 'Entry',
-      events: [{ id: '1', label: 'Event' }],
+      id: 'foundations',
+      title: 'Foundations',
+      start: -2000,
+      end: null,
+      places: ['Gaza'],
+      sources: ['sayigh1997'],
+      summary: 'Summary',
+      tags: ['foundations'],
+      certainty: 'medium',
     })
-    expect(result.success).toBe(false)
+    expect(result.success).toBe(true)
   })
 })

--- a/tests/unit/content.test.ts
+++ b/tests/unit/content.test.ts
@@ -91,7 +91,11 @@ describe('lib/content', () => {
 
   it('reads entries using resolvePath with branch awareness', async () => {
     const baseCollection = collections.find((item) => item.id === 'chapters_en')!
-    const collection = { ...baseCollection, resolvePath: vi.fn(baseCollection.resolvePath) }
+    const baseResolvePath = baseCollection.resolvePath
+    if (!baseResolvePath) {
+      throw new Error('chapters_en collection must define resolvePath')
+    }
+    const collection = { ...baseCollection, resolvePath: vi.fn(baseResolvePath) }
     const client = {} as any
     const markdown = Buffer.from(
       `---\ntitle: Prologue\nslug: prologue\nlanguage: en\n---\nBody text.\n`,

--- a/tests/unit/content.test.ts
+++ b/tests/unit/content.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, beforeEach, it, vi } from 'vitest'
+import { collections } from '@/lib/collections'
+import { listEntries, serializeEntry } from '@/lib/content'
+
+const githubMocks = vi.hoisted(() => ({
+  listDirectory: vi.fn(),
+  getFile: vi.fn(),
+  getLatestCommitForPath: vi.fn(),
+}))
+
+vi.mock('@/lib/github', () => ({
+  listDirectory: githubMocks.listDirectory,
+  getFile: githubMocks.getFile,
+  getLatestCommitForPath: githubMocks.getLatestCommitForPath,
+}))
+
+describe('lib/content', () => {
+  beforeEach(() => {
+    githubMocks.listDirectory.mockReset()
+    githubMocks.getFile.mockReset()
+    githubMocks.getLatestCommitForPath.mockReset()
+  })
+
+  it('lists english chapter entries using filename-derived slug', async () => {
+    const collection = collections.find((item) => item.id === 'chapters_en')!
+    const client = {} as any
+    githubMocks.listDirectory.mockResolvedValue([
+      { name: '001-prologue.mdx', path: 'content/chapters/001-prologue.mdx', sha: 'abc', type: 'file' },
+      { name: '001-prologue.ar.mdx', path: 'content/chapters/001-prologue.ar.mdx', sha: 'def', type: 'file' },
+    ])
+    const markdown = Buffer.from(
+      `---\ntitle: Prologue\nslug: prologue\nlanguage: en\n---\nBody text.\n`,
+      'utf-8',
+    ).toString('base64')
+    githubMocks.getFile.mockImplementation(async (_client, path: string) => ({
+      sha: 'abc',
+      content: markdown,
+      encoding: 'base64',
+      path,
+    }))
+    githubMocks.getLatestCommitForPath.mockResolvedValue({
+      sha: 'commit',
+      commit: { committer: { date: '2024-01-01T00:00:00Z' } },
+    })
+
+    const entries = await listEntries(client, collection)
+    expect(entries).toHaveLength(1)
+    expect(entries[0].slug).toBe('001-prologue')
+    expect(entries[0].title).toBe('Prologue')
+    expect(entries[0].path).toBe('content/chapters/001-prologue.mdx')
+  })
+
+  it('serializes yaml entries with newline termination', () => {
+    const collection = collections.find((item) => item.id === 'timeline')!
+    const serialized = serializeEntry(collection, {
+      frontmatter: {},
+      data: {
+        id: 'foundations',
+        title: 'Foundations',
+        start: -2000,
+        end: null,
+        places: ['Gaza'],
+        sources: ['sayigh1997'],
+        summary: 'Summary',
+        tags: ['foundations'],
+        certainty: 'medium',
+      },
+    })
+    expect(serialized.endsWith('\n')).toBe(true)
+  })
+
+  it('lists single-file json collections as a single entry', async () => {
+    const collection = collections.find((item) => item.id === 'bibliography')!
+    const client = {} as any
+    githubMocks.getFile.mockResolvedValue({
+      sha: 'sha',
+      content: Buffer.from(JSON.stringify([{ id: 'one' }]), 'utf-8').toString('base64'),
+      encoding: 'base64',
+      path: 'data/bibliography.json',
+    })
+    githubMocks.getLatestCommitForPath.mockResolvedValue({
+      sha: 'commit',
+      commit: { committer: { date: '2024-01-01T00:00:00Z' } },
+    })
+    const entries = await listEntries(client, collection)
+    expect(entries).toHaveLength(1)
+    expect(entries[0].slug).toBe('bibliography')
+    expect(entries[0].title).toBe('Bibliography')
+    expect(entries[0].path).toBe('data/bibliography.json')
+  })
+})


### PR DESCRIPTION
## Summary
- align CMS collections with the repo's .mdx chapters, YAML timeline data, and single-file JSON datasets
- update content helpers and admin APIs to preserve filenames while supporting YAML/JSON editors
- add a zero-config LibreTranslate endpoint and UI to draft Arabic counterparts directly from the CMS

## Testing
- pnpm install
- pnpm build
- pnpm test:unit

------
https://chatgpt.com/codex/tasks/task_b_690a87ad533c832eb90709cfbd0f0653