### PR TITLE
fix(translate): enforce Arabic output and preserve MDX; fail safe on errors without saving

### DIFF
--- a/app/api/admin/save/route.ts
+++ b/app/api/admin/save/route.ts
@@ -14,6 +14,8 @@ import {
   resolveCommitAuthor,
   updatePullRequestBody,
 } from '@/lib/github'
+import { hasEnoughArabic } from '@/lib/arabic'
+import { translateMdxPreserving, translatePlain } from '@/lib/translate'
 import { rateLimit } from '@/lib/rate-limit'
 import { sanitizeFilename, slugify, stripArabicSuffix, stripNumericPrefix } from '@/lib/slugs'
 
@@ -130,6 +132,59 @@ export const POST = async (req: NextRequest) => {
     }
   }
 
+  let markdownBodyContent = typeof markdownBody === 'string' ? markdownBody : ''
+
+  if (collection.format === 'markdown' && collection.id === 'chapters_ar') {
+    const frontmatterRecord = validated as Record<string, unknown>
+    frontmatterRecord.language = 'ar'
+
+    const ensureArabic = async (
+      value: string,
+      translator: (input: string, source?: string, target?: string) => Promise<string>,
+    ) => {
+      if (!value.trim()) {
+        return value
+      }
+      if (hasEnoughArabic(value)) {
+        return value
+      }
+      return translator(value, 'en', 'ar')
+    }
+
+    try {
+      if (typeof frontmatterRecord.title === 'string') {
+        frontmatterRecord.title = await ensureArabic(frontmatterRecord.title, translatePlain)
+      }
+      if (typeof frontmatterRecord.summary === 'string') {
+        frontmatterRecord.summary = await ensureArabic(frontmatterRecord.summary, translatePlain)
+      }
+      if (markdownBodyContent) {
+        if (!hasEnoughArabic(markdownBodyContent)) {
+          markdownBodyContent = await translateMdxPreserving(markdownBodyContent, 'en', 'ar')
+        }
+      }
+    } catch (error) {
+      return NextResponse.json(
+        { error: 'Arabic translation failed; nothing was saved.' },
+        { status: 502 },
+      )
+    }
+
+    const titleValue = typeof frontmatterRecord.title === 'string' ? frontmatterRecord.title : ''
+    if (titleValue.trim() && !hasEnoughArabic(titleValue)) {
+      return NextResponse.json({ error: 'Arabic title validation failed.' }, { status: 502 })
+    }
+    if (typeof frontmatterRecord.summary === 'string') {
+      const summaryValue = frontmatterRecord.summary
+      if (summaryValue.trim() && !hasEnoughArabic(summaryValue)) {
+        return NextResponse.json({ error: 'Arabic summary validation failed.' }, { status: 502 })
+      }
+    }
+    if (markdownBodyContent.trim() && !hasEnoughArabic(markdownBodyContent)) {
+      return NextResponse.json({ error: 'Arabic body validation failed.' }, { status: 502 })
+    }
+  }
+
   const branchWorkflow: 'draft' | 'publish' = workflow === 'draft' ? 'draft' : workflow === 'publish' ? 'publish' : collection.defaultWorkflow
   const branchName = branchWorkflow === 'draft' ? `cms/${slug}` : undefined
 
@@ -150,7 +205,7 @@ export const POST = async (req: NextRequest) => {
   const payload = collection.format === 'markdown'
     ? {
         frontmatter: validated as Record<string, unknown>,
-        body: typeof markdownBody === 'string' ? markdownBody : '',
+        body: markdownBodyContent,
       }
     : {
         frontmatter: {},

--- a/app/api/admin/save/route.ts
+++ b/app/api/admin/save/route.ts
@@ -170,19 +170,6 @@ export const POST = async (req: NextRequest) => {
       )
     }
 
-    const titleValue = typeof frontmatterRecord.title === 'string' ? frontmatterRecord.title : ''
-    if (titleValue.trim() && !hasEnoughArabic(titleValue)) {
-      return NextResponse.json({ error: 'Arabic title validation failed.' }, { status: 502 })
-    }
-    if (typeof frontmatterRecord.summary === 'string') {
-      const summaryValue = frontmatterRecord.summary
-      if (summaryValue.trim() && !hasEnoughArabic(summaryValue)) {
-        return NextResponse.json({ error: 'Arabic summary validation failed.' }, { status: 502 })
-      }
-    }
-    if (markdownBodyContent.trim() && !hasEnoughArabic(markdownBodyContent)) {
-      return NextResponse.json({ error: 'Arabic body validation failed.' }, { status: 502 })
-    }
   }
 
   const branchWorkflow: 'draft' | 'publish' = workflow === 'draft' ? 'draft' : workflow === 'publish' ? 'publish' : collection.defaultWorkflow

--- a/lib/arabic.ts
+++ b/lib/arabic.ts
@@ -1,0 +1,10 @@
+export const ARABIC_RE = /[\u0600-\u06FF]/g
+
+export const arabicCoverage = (value: string) => {
+  if (!value) return 0
+  const matches = value.match(ARABIC_RE)
+  const count = matches ? matches.length : 0
+  return count / value.length
+}
+
+export const hasEnoughArabic = (value: string, threshold = 0.15) => arabicCoverage(value) >= threshold

--- a/lib/translate.ts
+++ b/lib/translate.ts
@@ -100,17 +100,22 @@ const segmentMdx = (mdx: string): Segment[] => {
 }
 
 const translateParagraphs = async (text: string, source: string, target: string) => {
-  const chunks = text.split(/\n{2,}/)
+  const parts = text.split(/(\n{2,})/)
   const output: string[] = []
-  for (const chunk of chunks) {
-    if (!chunk.trim()) {
-      output.push(chunk)
+  for (let index = 0; index < parts.length; index += 1) {
+    const segment = parts[index]
+    if (index % 2 === 1) {
+      output.push(segment)
       continue
     }
-    const translated = await callProvider(chunk, source, target)
+    if (!segment.trim()) {
+      output.push(segment)
+      continue
+    }
+    const translated = await callProvider(segment, source, target)
     output.push(translated)
   }
-  return output.join('\n\n')
+  return output.join('')
 }
 
 export const callProvider = async (input: string, source: string, target: string) => {
@@ -156,9 +161,6 @@ export const translateMdxPreserving = async (mdx: string, source = 'en', target 
       continue
     }
     const translated = await translateParagraphs(segment.text, source, target)
-    if (!hasEnoughArabic(translated) && segment.text.trim()) {
-      throw new Error('Non-Arabic output')
-    }
     segment.text = translated
   }
   const translatedPortion = segments

--- a/lib/translate.ts
+++ b/lib/translate.ts
@@ -1,60 +1,173 @@
-import crypto from 'node:crypto';
+import { hasEnoughArabic } from './arabic'
 
-const cache = new Map<string, Promise<string>>();
+const TRANSLATE_URL = 'https://libretranslate.com/translate'
 
-type TranslateOptions = {
-  target: string;
-  source?: string;
-  fallback?: string;
-};
-
-/**
- * Translate text using a LibreTranslate-compatible API.
- * Falls back to the original text when no service is configured or on error.
- */
-export async function translateText(text: string, options: TranslateOptions): Promise<string> {
-  const trimmed = text?.trim();
-  if (!trimmed) return text;
-
-  const target = options.target;
-  const source = options.source ?? 'en';
-  const fallback = options.fallback ?? text;
-  const endpoint = process.env.LIBRETRANSLATE_URL;
-
-  if (!endpoint) return fallback;
-
-  const cacheKey = `${source}:${target}:${crypto.createHash('sha1').update(trimmed).digest('hex')}`;
-  if (!cache.has(cacheKey)) {
-    cache.set(cacheKey, requestTranslation(trimmed, { source, target }).catch(() => fallback));
-  }
-
-  return cache.get(cacheKey)!;
+type Segment = {
+  text: string
+  translate: boolean
 }
 
-async function requestTranslation(text: string, opts: { source: string; target: string }): Promise<string> {
-  const endpoint = process.env.LIBRETRANSLATE_URL!;
-  const url = endpoint.replace(/\/$/, '') + '/translate';
-
-  const res = await fetch(url, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      ...(process.env.LIBRETRANSLATE_KEY ? { Authorization: `Bearer ${process.env.LIBRETRANSLATE_KEY}` } : {}),
-    },
-    body: JSON.stringify({
-      q: text,
-      source: opts.source,
-      target: opts.target,
-      format: 'text',
-    }),
-  });
-
-  if (!res.ok) {
-    throw new Error(`translate ${res.status}`);
+const pushSegment = (segments: Segment[], text: string, translate: boolean) => {
+  if (!text) return
+  const last = segments.at(-1)
+  if (last && last.translate === translate) {
+    last.text += text
+    return
   }
+  segments.push({ text, translate })
+}
 
-  const data = (await res.json()) as { translatedText?: string };
-  const translated = data.translatedText?.trim();
-  if (!translated) throw new Error('empty translation');
-  return translated;
+const findMatching = (source: string, start: number, open: string, close: string) => {
+  let depth = 0
+  for (let index = start; index < source.length; index += 1) {
+    const char = source[index]
+    if (char === open) {
+      depth += 1
+    } else if (char === close) {
+      if (depth === 0) {
+        return index
+      }
+      depth -= 1
+    }
+  }
+  return -1
+}
+
+const segmentMdx = (mdx: string): Segment[] => {
+  const segments: Segment[] = []
+  let index = 0
+  while (index < mdx.length) {
+    if (mdx.startsWith('```', index)) {
+      const closing = mdx.indexOf('```', index + 3)
+      const end = closing === -1 ? mdx.length : closing + 3
+      pushSegment(segments, mdx.slice(index, end), false)
+      index = end
+      continue
+    }
+
+    const char = mdx[index]
+
+    if (char === '`') {
+      const closing = mdx.indexOf('`', index + 1)
+      const end = closing === -1 ? mdx.length : closing + 1
+      pushSegment(segments, mdx.slice(index, end), false)
+      index = end
+      continue
+    }
+
+    if (char === '<') {
+      const closing = mdx.indexOf('>', index + 1)
+      if (closing === -1) {
+        pushSegment(segments, mdx.slice(index), false)
+        break
+      }
+      pushSegment(segments, mdx.slice(index, closing + 1), false)
+      index = closing + 1
+      continue
+    }
+
+    if (char === '[' || (char === '!' && mdx[index + 1] === '[')) {
+      const isImage = char === '!'
+      const bracketStart = isImage ? index + 1 : index
+      const closeBracket = findMatching(mdx, bracketStart + 1, '[', ']')
+      if (closeBracket === -1) {
+        pushSegment(segments, mdx[index], true)
+        index += 1
+        continue
+      }
+      if (isImage) {
+        pushSegment(segments, '![', false)
+      } else {
+        pushSegment(segments, '[', false)
+      }
+      const inner = mdx.slice(bracketStart + 1, closeBracket)
+      pushSegment(segments, inner, true)
+      pushSegment(segments, ']', false)
+      index = closeBracket + 1
+      if (mdx[index] === '(') {
+        const closeParen = findMatching(mdx, index + 1, '(', ')')
+        const end = closeParen === -1 ? mdx.length : closeParen + 1
+        pushSegment(segments, mdx.slice(index, end), false)
+        index = end
+      }
+      continue
+    }
+
+    pushSegment(segments, char, true)
+    index += 1
+  }
+  return segments
+}
+
+const translateParagraphs = async (text: string, source: string, target: string) => {
+  const chunks = text.split(/\n{2,}/)
+  const output: string[] = []
+  for (const chunk of chunks) {
+    if (!chunk.trim()) {
+      output.push(chunk)
+      continue
+    }
+    const translated = await callProvider(chunk, source, target)
+    output.push(translated)
+  }
+  return output.join('\n\n')
+}
+
+export const callProvider = async (input: string, source: string, target: string) => {
+  const response = await fetch(TRANSLATE_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ q: input, source, target, format: 'text' }),
+  })
+  if (!response.ok) {
+    throw new Error(`Translation provider error: ${response.status}`)
+  }
+  const json = await response.json()
+  const output =
+    typeof json.translatedText === 'string'
+      ? json.translatedText
+      : typeof json.translated === 'string'
+        ? json.translated
+        : ''
+  if (!output) {
+    throw new Error('Empty translation')
+  }
+  return output
+}
+
+export const translatePlain = async (text: string, source = 'en', target = 'ar') => {
+  if (!text?.trim()) {
+    return text
+  }
+  const translated = await translateParagraphs(text, source, target)
+  if (!hasEnoughArabic(translated)) {
+    throw new Error('Non-Arabic output')
+  }
+  return translated
+}
+
+export const translateMdxPreserving = async (mdx: string, source = 'en', target = 'ar') => {
+  if (!mdx?.trim()) {
+    return mdx
+  }
+  const segments = segmentMdx(mdx)
+  for (const segment of segments) {
+    if (!segment.translate) {
+      continue
+    }
+    const translated = await translateParagraphs(segment.text, source, target)
+    if (!hasEnoughArabic(translated) && segment.text.trim()) {
+      throw new Error('Non-Arabic output')
+    }
+    segment.text = translated
+  }
+  const translatedPortion = segments
+    .filter((segment) => segment.translate)
+    .map((segment) => segment.text)
+    .join('')
+  if (translatedPortion.trim() && !hasEnoughArabic(translatedPortion)) {
+    throw new Error('Non-Arabic output')
+  }
+  const output = segments.map((segment) => segment.text).join('')
+  return output
 }

--- a/tests/unit/admin/save-route.test.ts
+++ b/tests/unit/admin/save-route.test.ts
@@ -14,8 +14,12 @@ const csrfMock = vi.hoisted(() => ({
 vi.mock('@/lib/api/csrf', () => csrfMock)
 
 const translateMock = vi.hoisted(() => ({
-  translatePlain: vi.fn(async () => 'عنوان عربي'),
-  translateMdxPreserving: vi.fn(async () => 'مرحبا بالعالم'),
+  translatePlain: vi.fn<
+    (text: string, source?: string, target?: string) => Promise<string>
+  >(async () => 'عنوان عربي'),
+  translateMdxPreserving: vi.fn<
+    (mdx: string, source?: string, target?: string) => Promise<string>
+  >(async () => 'مرحبا بالعالم'),
 }))
 
 vi.mock('@/lib/translate', () => translateMock)

--- a/tests/unit/admin/save-route.test.ts
+++ b/tests/unit/admin/save-route.test.ts
@@ -14,11 +14,12 @@ const csrfMock = vi.hoisted(() => ({
 vi.mock('@/lib/api/csrf', () => csrfMock)
 
 const translateMock = vi.hoisted(() => ({
-  translatePlain: vi.fn<
-    (text: string, source?: string, target?: string) => Promise<string>
-  >(async () => 'عنوان عربي'),
+  translatePlain: vi.fn<[text: string, source?: string, target?: string], Promise<string>>(
+    async () => 'عنوان عربي',
+  ),
   translateMdxPreserving: vi.fn<
-    (mdx: string, source?: string, target?: string) => Promise<string>
+    [mdx: string, source?: string, target?: string],
+    Promise<string>
   >(async () => 'مرحبا بالعالم'),
 }))
 

--- a/tests/unit/admin/translate-route.test.ts
+++ b/tests/unit/admin/translate-route.test.ts
@@ -1,0 +1,80 @@
+import { NextRequest } from 'next/server'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const authMock = vi.hoisted(() => ({
+  ensureAuth: vi.fn(() => ({ ok: true, mode: 'token', session: null })),
+}))
+
+vi.mock('@/lib/api/auth', () => authMock)
+
+import { POST } from '@/app/api/admin/translate/route'
+
+describe('POST /api/admin/translate', () => {
+  const originalFetch = global.fetch
+
+  beforeEach(() => {
+    authMock.ensureAuth.mockReturnValue({ ok: true, mode: 'token', session: null })
+  })
+
+  afterEach(() => {
+    global.fetch = originalFetch
+    authMock.ensureAuth.mockClear()
+  })
+
+  it('returns Arabic translation on success', async () => {
+    global.fetch = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ translatedText: 'مرحبا بالعالم' }),
+    })) as any
+
+    const request = new NextRequest('http://localhost/api/admin/translate', {
+      method: 'POST',
+      body: JSON.stringify({ text: 'Hello world', source: 'en', target: 'ar', mode: 'plain' }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+
+    const response = await POST(request)
+    expect(response.status).toBe(200)
+    const json = await response.json()
+    expect(json.translated).toBe('مرحبا بالعالم')
+  })
+
+  it('returns 502 when provider responds with an error', async () => {
+    global.fetch = vi.fn(async () => ({
+      ok: false,
+      status: 503,
+      json: async () => ({ error: 'Service unavailable' }),
+    })) as any
+
+    const request = new NextRequest('http://localhost/api/admin/translate', {
+      method: 'POST',
+      body: JSON.stringify({ text: 'Hello world', source: 'en', target: 'ar', mode: 'plain' }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+
+    const response = await POST(request)
+    expect(response.status).toBe(502)
+    const json = await response.json()
+    expect(json.error).toMatch(/Translation/)
+  })
+
+  it('returns 502 when translated text is not Arabic', async () => {
+    global.fetch = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ translatedText: 'Hello world' }),
+    })) as any
+
+    const request = new NextRequest('http://localhost/api/admin/translate', {
+      method: 'POST',
+      body: JSON.stringify({ text: 'Hello world', source: 'en', target: 'ar', mode: 'plain' }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+
+    const response = await POST(request)
+    expect(response.status).toBe(502)
+    const json = await response.json()
+    expect(json.error).toBeDefined()
+  })
+})


### PR DESCRIPTION
## Summary
- add Arabic coverage utilities and MDX-aware translation helpers that validate provider output
- tighten the translation API, admin client, and save pipeline to require real Arabic content for `chapters_ar`
- expand unit coverage to exercise translation failures and server-side enforcement logic

## Testing
- pnpm test:unit

------
https://chatgpt.com/codex/tasks/task_b_690b637963ec832eb73ada8d94e013dd