### PR TITLE
Harden Arabic translation flow with provider fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Create an `.env.local` (for local dev) or configure the variables on Vercel:
 | `CMS_AUTH_MODE` | `oauth` (default) or `token` |
 | `CMS_GITHUB_REPO` | `owner/name` of the content repo |
 | `CMS_GITHUB_BRANCH` | Default branch, usually `main` |
+| `CMS_TRANSLATE_URL` | Optional translation endpoint override (falls back to public mirrors) |
+| `CMS_TRANSLATE_API_KEY` | Optional API key passed to providers that require it |
 | `ALLOWED_EMAILS` | Comma separated allowlist (optional) |
 | `ALLOWED_GITHUB_LOGINS` | Comma separated allowlist (optional) |
 | `BASIC_AUTH_USER` / `BASIC_AUTH_PASS` | Optional basic auth for token mode |

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -507,9 +507,10 @@ const AdminPage = () => {
         return
       } catch (fallbackError) {
         const rawMessage = (fallbackError as Error).message
-        const displayMessage = rawMessage && rawMessage !== 'Failed to fetch'
-          ? rawMessage
-          : translationErrorMessage
+        const displayMessage =
+          rawMessage && rawMessage !== 'Failed to fetch'
+            ? rawMessage
+            : translationErrorMessage
         pushToast('error', displayMessage)
       }
     } finally {

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -420,6 +420,44 @@ const AdminPage = () => {
       }
       return translated
     }
+
+    const saveArabicDraft = async (frontmatter: Record<string, unknown>, body: string) => {
+      const arabicSlug = addArabicSuffix(englishSlug)
+      const payload: Record<string, unknown> = {
+        collection: 'chapters_ar',
+        slug: arabicSlug,
+        originalSlug: arabicSlug,
+        workflow: 'draft',
+        frontmatter,
+        body,
+      }
+      const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+      if (csrfToken) {
+        headers['x-csrf-token'] = csrfToken
+      }
+      const response = await fetch('/api/admin/save', {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(payload),
+      })
+      if (!response.ok) {
+        const error = await response.json().catch(() => ({ error: 'Unable to save Arabic translation' }))
+        throw new Error(error.error ?? 'Unable to save Arabic translation')
+      }
+      return response.json()
+    }
+
+    const handleSaveSuccess = async (result: Record<string, unknown>, fallback = false) => {
+      if (typeof result.prUrl === 'string' && result.prUrl) {
+        pushToast('success', `Arabic draft ready: ${result.prUrl}`)
+      } else {
+        pushToast('success', fallback ? 'Arabic translation saved via server translation' : 'Arabic translation saved')
+      }
+      if (selectedCollection === 'chapters_ar') {
+        await loadEntries('chapters_ar')
+      }
+    }
+
     setTranslating(true)
     try {
       const originalFrontmatter = editorState.frontmatter
@@ -454,43 +492,26 @@ const AdminPage = () => {
         translatedFrontmatter.summary = translatedSummary
       }
 
-      const arabicSlug = addArabicSuffix(englishSlug)
-      const payload: Record<string, unknown> = {
-        collection: 'chapters_ar',
-        slug: arabicSlug,
-        originalSlug: arabicSlug,
-        workflow: 'draft',
-        frontmatter: translatedFrontmatter,
-        body: translatedBody,
-      }
-      const headers: Record<string, string> = { 'Content-Type': 'application/json' }
-      if (csrfToken) {
-        headers['x-csrf-token'] = csrfToken
-      }
-      const response = await fetch('/api/admin/save', {
-        method: 'POST',
-        headers,
-        body: JSON.stringify(payload),
-      })
-      if (!response.ok) {
-        const error = await response.json().catch(() => ({ error: 'Unable to save Arabic translation' }))
-        throw new Error(error.error ?? 'Unable to save Arabic translation')
-      }
-      const result = await response.json()
-      if (result.prUrl) {
-        pushToast('success', `Arabic draft ready: ${result.prUrl}`)
-      } else {
-        pushToast('success', 'Arabic translation saved')
-      }
-      if (selectedCollection === 'chapters_ar') {
-        await loadEntries('chapters_ar')
-      }
+      const result = await saveArabicDraft(translatedFrontmatter, translatedBody)
+      await handleSaveSuccess(result)
+      return
     } catch (error) {
-      const rawMessage = (error as Error).message
-      const displayMessage = rawMessage && rawMessage !== 'Failed to fetch'
-        ? rawMessage
-        : translationErrorMessage
-      pushToast('error', displayMessage)
+      console.warn('Client-side translation failed, falling back to server translation', error)
+      const fallbackFrontmatter: Record<string, unknown> = {
+        ...editorState.frontmatter,
+        language: 'ar',
+      }
+      try {
+        const result = await saveArabicDraft(fallbackFrontmatter, editorState.body)
+        await handleSaveSuccess(result, true)
+        return
+      } catch (fallbackError) {
+        const rawMessage = (fallbackError as Error).message
+        const displayMessage = rawMessage && rawMessage !== 'Failed to fetch'
+          ? rawMessage
+          : translationErrorMessage
+        pushToast('error', displayMessage)
+      }
     } finally {
       setTranslating(false)
     }

--- a/lib/translate.ts
+++ b/lib/translate.ts
@@ -204,9 +204,20 @@ export const callProvider = async (input: string, source: string, target: string
         })
 
         if (!response.ok) {
-          if ((response.status === 401 || response.status === 403) && !apiKey) {
-            errors.push(`${provider.url} requires an API key`)
-            shouldRetryWithForm = false
+          if (response.status === 401 || response.status === 403) {
+            if (!apiKey && provider.requiresKey) {
+              errors.push(`${provider.url} requires an API key`)
+              shouldRetryWithForm = false
+              break
+            }
+
+            if (mode === 'json') {
+              shouldRetryWithForm = true
+              errors.push(`${provider.url} responded with ${response.status}`)
+              continue
+            }
+
+            errors.push(`${provider.url} responded with ${response.status}`)
             break
           }
 

--- a/tests/unit/admin/translate-route.test.ts
+++ b/tests/unit/admin/translate-route.test.ts
@@ -11,14 +11,17 @@ import { POST } from '@/app/api/admin/translate/route'
 
 describe('POST /api/admin/translate', () => {
   const originalFetch = global.fetch
+  const originalEnv = { ...process.env }
 
   beforeEach(() => {
     authMock.ensureAuth.mockReturnValue({ ok: true, mode: 'token', session: null })
+    process.env = { ...originalEnv }
   })
 
   afterEach(() => {
     global.fetch = originalFetch
     authMock.ensureAuth.mockClear()
+    process.env = { ...originalEnv }
   })
 
   it('returns Arabic translation on success', async () => {
@@ -40,12 +43,19 @@ describe('POST /api/admin/translate', () => {
     expect(json.translated).toBe('مرحبا بالعالم')
   })
 
-  it('returns 502 when provider responds with an error', async () => {
-    global.fetch = vi.fn(async () => ({
-      ok: false,
-      status: 503,
-      json: async () => ({ error: 'Service unavailable' }),
-    })) as any
+  it('falls back to secondary provider when the first provider fails', async () => {
+    const responses = [
+      { ok: false, status: 404, json: async () => ({}) },
+      { ok: false, status: 404, json: async () => ({}) },
+      { ok: true, status: 200, json: async () => ({ translatedText: 'مرحبا بالعالم' }) },
+    ]
+    global.fetch = vi.fn(async () => {
+      const next = responses.shift()
+      if (!next) {
+        throw new Error('No mock response available')
+      }
+      return next as any
+    }) as any
 
     const request = new NextRequest('http://localhost/api/admin/translate', {
       method: 'POST',
@@ -54,9 +64,37 @@ describe('POST /api/admin/translate', () => {
     })
 
     const response = await POST(request)
-    expect(response.status).toBe(502)
+    expect(response.status).toBe(200)
     const json = await response.json()
-    expect(json.error).toMatch(/Translation/)
+    expect(json.translated).toBe('مرحبا بالعالم')
+    expect(global.fetch).toHaveBeenCalledTimes(3)
+  })
+
+  it('skips providers that require an API key when none is configured', async () => {
+    process.env.CMS_TRANSLATE_URL = 'https://custom.example/translate'
+    const responses = [
+      { ok: false, status: 401, json: async () => ({}) },
+      { ok: true, status: 200, json: async () => ({ translatedText: 'مرحبا بالعالم' }) },
+    ]
+    global.fetch = vi.fn(async () => {
+      const next = responses.shift()
+      if (!next) {
+        throw new Error('No mock response available')
+      }
+      return next as any
+    }) as any
+
+    const request = new NextRequest('http://localhost/api/admin/translate', {
+      method: 'POST',
+      body: JSON.stringify({ text: 'Hello world', source: 'en', target: 'ar', mode: 'plain' }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+
+    const response = await POST(request)
+    expect(response.status).toBe(200)
+    const json = await response.json()
+    expect(json.translated).toBe('مرحبا بالعالم')
+    expect(global.fetch).toHaveBeenCalledTimes(2)
   })
 
   it('returns 502 when translated text is not Arabic', async () => {
@@ -76,5 +114,24 @@ describe('POST /api/admin/translate', () => {
     expect(response.status).toBe(502)
     const json = await response.json()
     expect(json.error).toBeDefined()
+  })
+
+  it('returns 502 when every provider fails', async () => {
+    global.fetch = vi.fn(async () => ({
+      ok: false,
+      status: 503,
+      json: async () => ({})
+    })) as any
+
+    const request = new NextRequest('http://localhost/api/admin/translate', {
+      method: 'POST',
+      body: JSON.stringify({ text: 'Hello world', source: 'en', target: 'ar', mode: 'plain' }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+
+    const response = await POST(request)
+    expect(response.status).toBe(502)
+    const json = await response.json()
+    expect(json.error).toMatch(/All translation providers failed/)
   })
 })


### PR DESCRIPTION
## Summary
- add multi-provider translation client with automatic format retries and optional environment overrides
- allow the admin "Translate to Arabic" action to fall back to server-side auto translation when preview fails
- extend admin translation/save unit tests and document optional translation env vars

## Testing
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_b_690b75b6c36c832e965880c71ce68822