### PR TITLE
Handle Arabic draft fallbacks when translators fail

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -448,7 +448,9 @@ const AdminPage = () => {
     }
 
     const handleSaveSuccess = async (result: Record<string, unknown>, fallback = false) => {
-      if (typeof result.prUrl === 'string' && result.prUrl) {
+      if (result.translationPending === true) {
+        pushToast('success', 'Arabic draft saved (translation pending).')
+      } else if (typeof result.prUrl === 'string' && result.prUrl) {
         pushToast('success', `Arabic draft ready: ${result.prUrl}`)
       } else {
         pushToast('success', fallback ? 'Arabic translation saved via server translation' : 'Arabic translation saved')

--- a/lib/translate.ts
+++ b/lib/translate.ts
@@ -288,6 +288,7 @@ export const callProvider = async (input: string, source: string, target: string
       if (advanceEndpoint) {
         continue
       }
+      break
     }
 
     await delay(100 + Math.floor(Math.random() * 200))

--- a/lib/translate.ts
+++ b/lib/translate.ts
@@ -23,6 +23,38 @@ const buildProviderList = () => {
 
 const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
+const DEFAULT_TIMEOUT_MS = 15_000
+
+const fetchWithTimeout = async (url: string, init: RequestInit, timeoutMs = DEFAULT_TIMEOUT_MS) => {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    return await fetch(url, { ...init, signal: controller.signal })
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+const buildEndpointVariants = (url: string) => {
+  const variants = [url]
+  try {
+    const parsed = new URL(url)
+    if (!parsed.pathname.endsWith('/translate')) {
+      return variants
+    }
+    const normalize = (path: string) => {
+      const next = new URL(url)
+      next.pathname = path
+      return next.toString()
+    }
+    variants.push(normalize('/api/translate'))
+    variants.push(normalize('/v1/translate'))
+  } catch {
+    // ignore URL parse issues and fall back to original URL only
+  }
+  return variants
+}
+
 const buildPayload = (input: string, source: string, target: string, apiKey?: string) => {
   const payload: Record<string, string> = {
     q: input,
@@ -188,53 +220,73 @@ export const callProvider = async (input: string, source: string, target: string
       continue
     }
 
-    let shouldRetryWithForm = false
+    const endpoints = buildEndpointVariants(provider.url)
 
-    for (const mode of ['json', 'form'] as const) {
-      if (mode === 'form' && !shouldRetryWithForm) {
-        break
-      }
-      try {
-        const response = await fetch(provider.url, {
-          method: 'POST',
-          headers: {
-            'Content-Type': mode === 'json' ? 'application/json' : 'application/x-www-form-urlencoded',
-          },
-          body: encodeBody(payload, mode),
-        })
+    for (const endpoint of endpoints) {
+      let shouldRetryWithForm = false
+      let advanceEndpoint = false
 
-        if (!response.ok) {
-          if (response.status === 401 || response.status === 403) {
-            if (!apiKey && provider.requiresKey) {
-              errors.push(`${provider.url} requires an API key`)
-              shouldRetryWithForm = false
+      for (const mode of ['json', 'form'] as const) {
+        if (mode === 'form' && !shouldRetryWithForm) {
+          continue
+        }
+        try {
+          const response = await fetchWithTimeout(endpoint, {
+            method: 'POST',
+            headers: {
+              'Content-Type':
+                mode === 'json' ? 'application/json' : 'application/x-www-form-urlencoded',
+            },
+            body: encodeBody(payload, mode),
+          })
+
+          if (!response.ok) {
+            if (response.status === 401 || response.status === 403) {
+              if (!apiKey && provider.requiresKey) {
+                errors.push(`${endpoint} requires an API key`)
+                shouldRetryWithForm = false
+                advanceEndpoint = true
+                break
+              }
+
+              if (mode === 'json') {
+                shouldRetryWithForm = true
+                errors.push(`${endpoint} responded with ${response.status}`)
+                continue
+              }
+
+              errors.push(`${endpoint} responded with ${response.status}`)
+              advanceEndpoint = true
               break
             }
 
-            if (mode === 'json') {
+            if (response.status === 404) {
+              errors.push(`${endpoint} responded with ${response.status}`)
+              advanceEndpoint = true
+              break
+            }
+
+            if (mode === 'json' && [406, 415].includes(response.status)) {
               shouldRetryWithForm = true
-              errors.push(`${provider.url} responded with ${response.status}`)
+              errors.push(`${endpoint} responded with ${response.status}`)
               continue
             }
 
-            errors.push(`${provider.url} responded with ${response.status}`)
+            errors.push(`${endpoint} responded with ${response.status}`)
+            advanceEndpoint = true
             break
           }
 
-          if (mode === 'json' && [404, 406, 415].includes(response.status)) {
-            shouldRetryWithForm = true
-            errors.push(`${provider.url} responded with ${response.status}`)
-            continue
-          }
-
-          errors.push(`${provider.url} responded with ${response.status}`)
+          return await extractTranslation(response)
+        } catch (error) {
+          errors.push(`${endpoint} failed: ${(error as Error).message}`)
+          advanceEndpoint = true
           break
         }
+      }
 
-        return await extractTranslation(response)
-      } catch (error) {
-        errors.push(`${provider.url} failed: ${(error as Error).message}`)
-        break
+      if (advanceEndpoint) {
+        continue
       }
     }
 

--- a/tests/unit/admin/save-route.test.ts
+++ b/tests/unit/admin/save-route.test.ts
@@ -75,11 +75,16 @@ describe('POST /api/admin/save', () => {
     Object.values(authMock).forEach((mock) => (mock as any).mock?.clear?.())
     Object.values(csrfMock).forEach((mock) => (mock as any).mock?.clear?.())
     Object.values(githubMocks).forEach((mock) => (mock as any).mock?.clear?.())
+    githubMocks.findPullRequestByBranch.mockImplementation(() => Promise.resolve(undefined))
     translatePlainSpy.mockClear()
     translateMdxPreservingSpy.mockClear()
     githubMocks.putFile.mockClear()
     githubMocks.listDirectory.mockClear()
     githubMocks.getFile.mockClear()
+    githubMocks.createPullRequest.mockResolvedValue({
+      html_url: 'https://example.com/pr',
+      number: 42,
+    } as any)
     for (const key of Object.keys(branchState)) {
       delete branchState[key]
     }
@@ -334,12 +339,12 @@ describe('POST /api/admin/save', () => {
     expect(translateMdxPreservingSpy).toHaveBeenCalledTimes(1)
     const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
     const fetchCalls = fetchMock.mock.calls
-    expect(fetchCalls.length).toBeGreaterThanOrEqual(5)
-    expect(fetchCalls[0]?.[1]?.headers?.['Content-Type']).toBe('application/json')
-    expect(fetchCalls[1]?.[1]?.headers?.['Content-Type']).toBe('application/x-www-form-urlencoded')
+    expect(fetchCalls.length).toBeGreaterThanOrEqual(3)
+    const contentTypes = fetchCalls.map((call) => call?.[1]?.headers?.['Content-Type'])
+    expect(contentTypes[0]).toBe('application/json')
   })
 
-  it('returns 502 when translation fails for an Arabic chapter', async () => {
+  it('saves a draft when translation fails for an Arabic chapter', async () => {
     translatePlainSpy.mockImplementationOnce(async () => {
       throw new Error('Service down')
     })
@@ -360,11 +365,16 @@ describe('POST /api/admin/save', () => {
     })
 
     const response = await POST(request)
-    expect(response.status).toBe(502)
-    expect(githubMocks.putFile).not.toHaveBeenCalled()
+    expect(response.status).toBe(200)
+    const json = await response.json()
+    expect(json.workflow).toBe('draft')
+    expect(json.translationPending).toBe(true)
+    expect(json.translationPendingFields).toContain('title')
+    expect(json.prUrl).toBe('https://example.com/pr')
+    expect(githubMocks.putFile).toHaveBeenCalled()
   })
 
-  it('returns 502 and skips saving when every provider fails', async () => {
+  it('returns draft details when every provider fails', async () => {
     global.fetch = vi.fn(async () => ({
       ok: false,
       status: 503,
@@ -387,7 +397,15 @@ describe('POST /api/admin/save', () => {
     })
 
     const response = await POST(request)
-    expect(response.status).toBe(502)
-    expect(githubMocks.putFile).not.toHaveBeenCalled()
+    expect(response.status).toBe(200)
+    const json = await response.json()
+    expect(json.workflow).toBe('draft')
+    expect(json.translationPending).toBe(true)
+    expect(json.translationPendingFields.sort()).toEqual(['body', 'summary', 'title'])
+    expect(json.prUrl).toBe('https://example.com/pr')
+    expect(githubMocks.putFile).toHaveBeenCalled()
+    const savedContent = (githubMocks.putFile as any).mock.calls.at(-1)?.[2] as string
+    expect(savedContent.startsWith('---'))
+    expect(savedContent).toContain('<!-- translation pending: body -->')
   })
 })

--- a/tests/unit/admin/save-route.test.ts
+++ b/tests/unit/admin/save-route.test.ts
@@ -405,7 +405,7 @@ describe('POST /api/admin/save', () => {
     expect(json.prUrl).toBe('https://example.com/pr')
     expect(githubMocks.putFile).toHaveBeenCalled()
     const savedContent = (githubMocks.putFile as any).mock.calls.at(-1)?.[2] as string
-    expect(savedContent.startsWith('---'))
+    expect(savedContent.startsWith('---')).toBe(true)
     expect(savedContent).toContain('<!-- translation pending: body -->')
   })
 })


### PR DESCRIPTION
## Summary
- allow Arabic chapter saves to continue by marking pending translations and forcing draft PRs
- note placeholder content when body translation fails and surface translationPending flags to the client
- harden the LibreTranslate client with timeouts and alternate endpoint retries, plus surface pending to the admin toast
- update unit coverage for draft fallback scenarios

## Testing
- pnpm test:unit

------
https://chatgpt.com/codex/tasks/task_b_690b9ab24610832ea7271cd594197fb8