### PR TITLE
Add Arabic 404 page + fix robots to disallow /api/admin

### DIFF
--- a/app/(site)/ar/not-found.tsx
+++ b/app/(site)/ar/not-found.tsx
@@ -1,0 +1,35 @@
+import Link from 'next/link';
+
+export default function NotFoundAr() {
+  return (
+    <main
+      id="main"
+      tabIndex={-1}
+      dir="rtl"
+      lang="ar"
+      className="min-h-screen flex flex-col items-center justify-center gap-6 p-8 text-center"
+    >
+      <h1 className="text-4xl font-bold tracking-tight">٤٠٤ — الصفحة غير موجودة</h1>
+      <p className="max-w-xl text-base text-gray-600">
+        لم نعثر على الصفحة المطلوبة. قد تكون أُزيلت أو نُقلت.
+      </p>
+      <nav className="flex flex-wrap items-center justify-center gap-4 text-sm font-medium">
+        <Link
+          href="/ar"
+          className="rounded px-4 py-2 underline underline-offset-4 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-current"
+          aria-label="العودة إلى الصفحة الرئيسية العربية"
+        >
+          العودة إلى الصفحة الرئيسية
+        </Link>
+        <Link
+          href="/"
+          className="rounded px-4 py-2 underline underline-offset-4 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-current"
+          dir="ltr"
+          aria-label="View English homepage"
+        >
+          English
+        </Link>
+      </nav>
+    </main>
+  );
+}

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -8,7 +8,7 @@ export default function robots(): MetadataRoute.Robots {
       {
         userAgent: '*',
         allow: '/',
-        disallow: ['/admin', '/api/cms'],
+        disallow: ['/admin', '/api/admin'],
       },
     ],
     sitemap: `${base}/sitemap.xml`,

--- a/tests/e2e/not-found.spec.ts
+++ b/tests/e2e/not-found.spec.ts
@@ -1,0 +1,21 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('localized not-found pages', () => {
+  test('renders english 404 with navigation links', async ({ page }) => {
+    const response = await page.goto('/def-not-a-real-route');
+    expect(response?.status()).toBe(404);
+
+    await expect(page.getByRole('heading', { name: '404 — Page not found' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Return home' })).toHaveAttribute('href', '/');
+    await expect(page.getByRole('link', { name: 'العربية' })).toHaveAttribute('href', '/ar');
+  });
+
+  test('renders arabic 404 with rtl layout and home link', async ({ page }) => {
+    const response = await page.goto('/ar/ليس-حقيقيًا');
+    expect(response?.status()).toBe(404);
+
+    await expect(page.getByRole('heading', { name: '٤٠٤ — الصفحة غير موجودة' })).toBeVisible();
+    await expect(page.locator('main#main')).toHaveAttribute('dir', 'rtl');
+    await expect(page.getByRole('link', { name: 'العودة إلى الصفحة الرئيسية العربية' })).toHaveAttribute('href', '/ar');
+  });
+});

--- a/tests/unit/robots.test.ts
+++ b/tests/unit/robots.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import robots from '@/app/robots';
+
+describe('robots.txt configuration', () => {
+  it('disallows admin surfaces and omits legacy cms api', () => {
+    const result = robots();
+    const rules = result.rules ?? [];
+    const disallowEntries = rules.flatMap((rule) => rule.disallow ?? []);
+
+    expect(disallowEntries).toContain('/admin');
+    expect(disallowEntries).toContain('/api/admin');
+    expect(disallowEntries).not.toContain('/api/cms');
+  });
+});

--- a/tests/unit/robots.test.ts
+++ b/tests/unit/robots.test.ts
@@ -4,7 +4,11 @@ import robots from '@/app/robots';
 describe('robots.txt configuration', () => {
   it('disallows admin surfaces and omits legacy cms api', () => {
     const result = robots();
-    const rules = result.rules ?? [];
+    const rules = Array.isArray(result.rules)
+      ? result.rules
+      : result.rules
+        ? [result.rules]
+        : [];
     const disallowEntries = rules
       .map((rule: { disallow?: string | string[] }) =>
         Array.isArray(rule.disallow)

--- a/tests/unit/robots.test.ts
+++ b/tests/unit/robots.test.ts
@@ -5,7 +5,15 @@ describe('robots.txt configuration', () => {
   it('disallows admin surfaces and omits legacy cms api', () => {
     const result = robots();
     const rules = result.rules ?? [];
-    const disallowEntries = rules.flatMap((rule) => rule.disallow ?? []);
+    const disallowEntries = rules
+      .map((rule: { disallow?: string | string[] }) =>
+        Array.isArray(rule.disallow)
+          ? rule.disallow
+          : rule.disallow
+            ? [rule.disallow]
+            : []
+      )
+      .flat();
 
     expect(disallowEntries).toContain('/admin');
     expect(disallowEntries).toContain('/api/admin');


### PR DESCRIPTION
## Summary
- Provide localized Arabic not-found page at app/(site)/ar/not-found.tsx
- Update robots rules to disallow /admin and /api/admin
- Add Playwright + Vitest coverage for not-found pages and robots disallow list

## Testing
- pnpm test
- pnpm test:e2e -- tests/e2e/not-found.spec.ts

------
https://chatgpt.com/codex/tasks/task_b_690bb97e0afc832eb395f5b507462b56