### PR TITLE
Secure admin UI: gate `/admin` when unauthenticated, disable ‘New’, add OAuth redirect

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -577,42 +577,68 @@ const AdminPage = () => {
   }
 
   const collection = collections.find((item) => item.id === selectedCollection) ?? null
+  const shouldGateAdmin = authMode === 'oauth' && requiresLogin
+  const header = (
+    <header className="border-b border-zinc-200 bg-white">
+      <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
+        <div>
+          <h1 className="text-lg font-semibold text-zinc-900">Palestine CMS Admin</h1>
+          {session ? (
+            <p className="text-xs text-zinc-500">
+              Signed in as {session.name ?? session.login}
+            </p>
+          ) : authMode === 'token' ? (
+            <p className="text-xs text-zinc-500">Token mode</p>
+          ) : null}
+        </div>
+        <div className="flex items-center gap-3 text-sm">
+          {authMode === 'oauth' && !requiresLogin ? (
+            <button
+              type="button"
+              onClick={handleSignOut}
+              className="rounded border border-zinc-300 px-3 py-1.5 text-sm text-zinc-700 transition hover:border-black hover:text-black"
+            >
+              Sign out
+            </button>
+          ) : null}
+          {authMode === 'oauth' && requiresLogin ? (
+            <a
+              href="/api/auth/signin"
+              className="rounded border border-black px-3 py-1.5 text-sm font-medium text-black transition hover:bg-black hover:text-white"
+            >
+              Sign in with GitHub
+            </a>
+          ) : null}
+        </div>
+      </div>
+    </header>
+  )
+
+  if (shouldGateAdmin) {
+    return (
+      <div className="flex min-h-screen flex-col bg-zinc-100">
+        {header}
+        <main className="flex flex-1 items-center justify-center px-6 py-12">
+          <div className="w-full max-w-sm rounded border border-zinc-200 bg-white p-6 text-center shadow-sm">
+            <h2 className="text-lg font-semibold text-zinc-900">Sign in required</h2>
+            <p className="mt-2 text-sm text-zinc-600">
+              Sign in with GitHub to manage the Palestine CMS content.
+            </p>
+            <a
+              href="/api/auth/signin"
+              className="mt-4 inline-flex items-center justify-center rounded border border-black px-3 py-2 text-sm font-medium text-black transition hover:bg-black hover:text-white"
+            >
+              Sign in with GitHub
+            </a>
+          </div>
+        </main>
+      </div>
+    )
+  }
 
   return (
     <div className="flex min-h-screen flex-col bg-zinc-100">
-      <header className="border-b border-zinc-200 bg-white">
-        <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
-          <div>
-            <h1 className="text-lg font-semibold text-zinc-900">Palestine CMS Admin</h1>
-            {session ? (
-              <p className="text-xs text-zinc-500">
-                Signed in as {session.name ?? session.login}
-              </p>
-            ) : authMode === 'token' ? (
-              <p className="text-xs text-zinc-500">Token mode</p>
-            ) : null}
-          </div>
-          <div className="flex items-center gap-3 text-sm">
-            {authMode === 'oauth' && !requiresLogin ? (
-              <button
-                type="button"
-                onClick={handleSignOut}
-                className="rounded border border-zinc-300 px-3 py-1.5 text-sm text-zinc-700 transition hover:border-black hover:text-black"
-              >
-                Sign out
-              </button>
-            ) : null}
-            {authMode === 'oauth' && requiresLogin ? (
-              <a
-                href="/api/auth/signin"
-                className="rounded border border-black px-3 py-1.5 text-sm font-medium text-black transition hover:bg-black hover:text-white"
-              >
-                Sign in with GitHub
-              </a>
-            ) : null}
-          </div>
-        </div>
-      </header>
+      {header}
 
       <main className="mx-auto flex w-full max-w-6xl flex-1 gap-6 px-6 py-6">
         <aside className="w-56">
@@ -645,6 +671,7 @@ const AdminPage = () => {
               onCreate={handleCreate}
               search={search}
               onSearch={setSearch}
+              disabled={requiresLogin}
             />
           )}
         </section>

--- a/components/EntryList.tsx
+++ b/components/EntryList.tsx
@@ -13,6 +13,7 @@ type Props = {
   onCreate: () => void
   search: string
   onSearch: (value: string) => void
+  disabled?: boolean
 }
 
 const formatDate = (value: string | null) => {
@@ -24,7 +25,7 @@ const formatDate = (value: string | null) => {
   return date.toLocaleString()
 }
 
-const EntryList = ({ entries, selected, onSelect, onCreate, search, onSearch }: Props) => {
+const EntryList = ({ entries, selected, onSelect, onCreate, search, onSearch, disabled = false }: Props) => {
   return (
     <div className="flex h-full flex-col">
       <div className="flex items-center gap-2 pb-3">
@@ -34,13 +35,16 @@ const EntryList = ({ entries, selected, onSelect, onCreate, search, onSearch }: 
           className="w-full rounded border border-zinc-300 px-3 py-2 text-sm focus:border-black focus:outline-none"
           placeholder="Search entries"
         />
-        <button
-          type="button"
-          onClick={onCreate}
-          className="rounded border border-black px-3 py-2 text-sm font-medium text-black transition hover:bg-black hover:text-white"
-        >
-          New
-        </button>
+        {disabled ? null : (
+          <button
+            type="button"
+            onClick={onCreate}
+            className="rounded border border-black px-3 py-2 text-sm font-medium text-black transition hover:bg-black hover:text-white"
+            data-testid="new-button"
+          >
+            New
+          </button>
+        )}
       </div>
       <div className="flex-1 overflow-y-auto rounded border border-zinc-200 bg-white">
         {entries.length === 0 ? (

--- a/middleware.ts
+++ b/middleware.ts
@@ -17,8 +17,17 @@ export function middleware(req: NextRequest) {
     return NextResponse.next()
   }
 
+  const pathname = req.nextUrl.pathname
   const mode = (process.env.CMS_AUTH_MODE ?? 'oauth').toLowerCase()
   if (mode !== 'token') {
+    const isAdminApi = pathname.startsWith('/api/admin')
+    const isAdminPage = pathname.startsWith('/admin')
+    if (isAdminPage && !isAdminApi) {
+      const session = req.cookies.get('cms_session')?.value
+      if (!session) {
+        return NextResponse.redirect(new URL('/api/auth/signin', req.url), 302)
+      }
+    }
     return NextResponse.next()
   }
 

--- a/tests/e2e/admin.spec.ts
+++ b/tests/e2e/admin.spec.ts
@@ -1,0 +1,33 @@
+import { expect, test } from '@playwright/test';
+
+const parseBaseURL = (value?: string) => {
+  try {
+    return value ? new URL(value) : null;
+  } catch {
+    return null;
+  }
+};
+
+test.describe('admin ui gating', () => {
+  test('hides controls and prompts sign-in when unauthenticated in OAuth mode', async ({ context, page }, testInfo) => {
+    const baseURL = testInfo.project.use.baseURL;
+    const parsedBaseURL = parseBaseURL(baseURL);
+
+    if (parsedBaseURL) {
+      await context.addCookies([
+        {
+          name: 'cms_session',
+          value: 'invalid',
+          url: parsedBaseURL.origin,
+          path: '/',
+        },
+      ]);
+    }
+
+    await page.goto('/admin');
+
+    await expect(page.getByRole('link', { name: 'Sign in with GitHub' })).toBeVisible();
+    await expect(page.getByText('Sign in required')).toBeVisible();
+    await expect(page.locator('[data-testid="new-button"]')).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Summary
- gate the admin SPA layout when OAuth logins are required, showing only the GitHub sign-in prompt
- hide the "New" control until edits are permitted and disable unauthorized creation attempts
- redirect unauthenticated OAuth traffic hitting `/admin` toward the GitHub sign-in endpoint and cover the flow with Playwright

## Testing
- npm run build
- npx playwright test tests/e2e/admin.spec.ts *(fails: browsers unavailable in sandbox)*

------
https://chatgpt.com/codex/tasks/task_b_690bc50bf3ec832ebbf744cb58887d86