### PR TITLE
Add security & caching headers + safe external-link handling (SEC-002, PERF-002, REL-002)

### DIFF
--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -18,12 +18,32 @@ function Cite({ id, children }: { id?: string; children?: React.ReactNode }) {
   );
 }
 
+function Anchor(props: React.AnchorHTMLAttributes<HTMLAnchorElement>) {
+  const { href = '', rel, target, ...rest } = props;
+  const isExternal = /^https?:\/\//i.test(href);
+  const relTokens = new Set<string>(
+    String(rel ?? '')
+      .split(/\s+/)
+      .filter(Boolean),
+  );
+
+  if (isExternal || target === '_blank') {
+    relTokens.add('noopener');
+    relTokens.add('noreferrer');
+  }
+
+  const finalRel = [...relTokens].join(' ');
+
+  return <a href={href} rel={finalRel || undefined} target={target} {...rest} />;
+}
+
 export function createMdxComponents(locale: 'en' | 'ar' = 'en') {
   const { Footnote, FootnotesSection } = createFootnotesManager(locale);
   return {
     components: {
       Cite,
       Footnote,
+      a: Anchor,
     },
     FootnotesSection,
   } as const;

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -6,6 +6,8 @@ const nextConfig = {
 
   async headers() {
     const connectSrcHosts = [
+      'ws:',
+      'wss:',
       'https://tile.openstreetmap.org',
       'https://a.tile.openstreetmap.org',
       'https://b.tile.openstreetmap.org',

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -13,6 +13,8 @@ const nextConfig = {
       'https://b.tile.openstreetmap.org',
       'https://c.tile.openstreetmap.org',
     ];
+    const openGraphCacheControl =
+      'public, s-maxage=86400, max-age=3600, stale-while-revalidate=604800';
     const csp = [
       "default-src 'self'",
       "base-uri 'none'",
@@ -56,7 +58,7 @@ const nextConfig = {
         headers: [
           {
             key: 'Cache-Control',
-            value: 'public, s-maxage=86400, max-age=3600, stale-while-revalidate=604800',
+            value: openGraphCacheControl,
           },
         ],
       },
@@ -65,7 +67,7 @@ const nextConfig = {
         headers: [
           {
             key: 'Cache-Control',
-            value: 'public, s-maxage=86400, max-age=3600, stale-while-revalidate=604800',
+            value: openGraphCacheControl,
           },
         ],
       },
@@ -74,7 +76,7 @@ const nextConfig = {
         headers: [
           {
             key: 'Cache-Control',
-            value: 'public, s-maxage=86400, max-age=3600, stale-while-revalidate=604800',
+            value: openGraphCacheControl,
           },
         ],
       },
@@ -83,7 +85,7 @@ const nextConfig = {
         headers: [
           {
             key: 'Cache-Control',
-            value: 'public, s-maxage=86400, max-age=3600, stale-while-revalidate=604800',
+            value: openGraphCacheControl,
           },
         ],
       },
@@ -92,7 +94,7 @@ const nextConfig = {
         headers: [
           {
             key: 'Cache-Control',
-            value: 'public, s-maxage=86400, max-age=3600, stale-while-revalidate=604800',
+            value: openGraphCacheControl,
           },
         ],
       },
@@ -101,7 +103,7 @@ const nextConfig = {
         headers: [
           {
             key: 'Cache-Control',
-            value: 'public, s-maxage=86400, max-age=3600, stale-while-revalidate=604800',
+            value: openGraphCacheControl,
           },
         ],
       },
@@ -110,7 +112,7 @@ const nextConfig = {
         headers: [
           {
             key: 'Cache-Control',
-            value: 'public, s-maxage=86400, max-age=3600, stale-while-revalidate=604800',
+            value: openGraphCacheControl,
           },
         ],
       },

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -4,6 +4,117 @@ const nextConfig = {
   experimental: { mdxRs: true },
   pageExtensions: ['ts', 'tsx', 'md', 'mdx'],
 
+  async headers() {
+    const connectSrcHosts = [
+      'https://tile.openstreetmap.org',
+      'https://a.tile.openstreetmap.org',
+      'https://b.tile.openstreetmap.org',
+      'https://c.tile.openstreetmap.org',
+    ];
+    const csp = [
+      "default-src 'self'",
+      "base-uri 'none'",
+      "object-src 'none'",
+      "frame-ancestors 'none'",
+      "script-src 'self' 'unsafe-inline'",
+      "style-src 'self' 'unsafe-inline'",
+      "img-src 'self' data: https:",
+      "font-src 'self' data:",
+      `connect-src 'self' ${connectSrcHosts.join(' ')}`,
+      'upgrade-insecure-requests',
+    ].join('; ');
+
+    // Extend script-src or connect-src if future analytics or third-party tooling is introduced.
+
+    return [
+      {
+        source: '/:path*',
+        headers: [
+          { key: 'Content-Security-Policy', value: csp },
+          { key: 'Strict-Transport-Security', value: 'max-age=31536000; includeSubDomains; preload' },
+          { key: 'X-Content-Type-Options', value: 'nosniff' },
+          { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+          { key: 'Permissions-Policy', value: 'geolocation=(), microphone=(), camera=(), browsing-topics=()' },
+        ],
+      },
+      {
+        source: '/images/:path*',
+        headers: [{ key: 'Cache-Control', value: 'public, max-age=31536000, immutable' }],
+      },
+      {
+        source: '/map/style.json',
+        headers: [{ key: 'Cache-Control', value: 'public, max-age=31536000, immutable' }],
+      },
+      {
+        source: '/_next/static/:path*',
+        headers: [{ key: 'Cache-Control', value: 'public, max-age=31536000, immutable' }],
+      },
+      {
+        source: '/opengraph-image',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'public, s-maxage=86400, max-age=3600, stale-while-revalidate=604800',
+          },
+        ],
+      },
+      {
+        source: '/chapters/:slug/opengraph-image',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'public, s-maxage=86400, max-age=3600, stale-while-revalidate=604800',
+          },
+        ],
+      },
+      {
+        source: '/ar/chapters/:slug/opengraph-image',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'public, s-maxage=86400, max-age=3600, stale-while-revalidate=604800',
+          },
+        ],
+      },
+      {
+        source: '/places/:id/opengraph-image',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'public, s-maxage=86400, max-age=3600, stale-while-revalidate=604800',
+          },
+        ],
+      },
+      {
+        source: '/ar/places/:id/opengraph-image',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'public, s-maxage=86400, max-age=3600, stale-while-revalidate=604800',
+          },
+        ],
+      },
+      {
+        source: '/timeline/:id/opengraph-image',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'public, s-maxage=86400, max-age=3600, stale-while-revalidate=604800',
+          },
+        ],
+      },
+      {
+        source: '/ar/timeline/:id/opengraph-image',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'public, s-maxage=86400, max-age=3600, stale-while-revalidate=604800',
+          },
+        ],
+      },
+    ];
+  },
+
   // Keep the private CMS shell reachable at /admin → static HTML
   async rewrites() {
     return [{ source: '/admin', destination: '/admin/index.html' }];


### PR DESCRIPTION
## Summary
- add global security headers with a CSP that accommodates OpenStreetMap tiles while hardening defaults (SEC-002)
- configure long-lived cache headers for static assets and tuned edge caching for Open Graph images (PERF-002)
- wrap MDX anchor rendering to ensure external links include noopener/noreferrer without affecting author intent (REL-002)

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_690bc9f508c8832ea6ce42e2d924cc44