### PR TITLE
Add Learn lessons to sitemap and metadata surfaces

### DIFF
--- a/app/learn/[slug]/opengraph-image.tsx
+++ b/app/learn/[slug]/opengraph-image.tsx
@@ -1,0 +1,46 @@
+import { ImageResponse } from 'next/og';
+import { loadLessonFrontmatter } from '@/lib/loaders.lessons';
+
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+export default function OgImage({ params }: { params: { slug: string } }) {
+  let title = 'Palestine: Learn';
+  let summary: string | undefined;
+
+  try {
+    const frontmatter = loadLessonFrontmatter(params.slug);
+    title = frontmatter.title ?? title;
+    summary = frontmatter.summary?.trim() || undefined;
+  } catch {
+    // fall back to defaults if lesson missing
+  }
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          background: '#0b0b0b',
+          color: '#fdfdfd',
+          padding: 64,
+          fontFamily: 'Inter, system-ui, sans-serif',
+          backgroundImage: 'radial-gradient(circle at 0% 100%, #222 0%, #0b0b0b 70%)',
+        }}
+      >
+        <div style={{ opacity: 0.7, fontSize: 22, letterSpacing: 2 }}>LEARN • PALESTINE</div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 24, maxWidth: 920 }}>
+          <div style={{ fontSize: 64, fontWeight: 700, lineHeight: 1.2 }}>{title}</div>
+          {summary ? (
+            <div style={{ fontSize: 30, lineHeight: 1.4, opacity: 0.85 }}>{summary}</div>
+          ) : null}
+        </div>
+      </div>
+    ),
+    size
+  );
+}

--- a/app/learn/[slug]/page.tsx
+++ b/app/learn/[slug]/page.tsx
@@ -51,13 +51,15 @@ export default async function LessonPage({ params }: { params: { slug: string } 
   const frontmatter = loadLessonFrontmatter(params.slug);
   const { components } = createMdxComponents('en');
 
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://palestine.example';
+
   const lessonLd = {
     '@context': 'https://schema.org',
     '@type': 'LearningResource',
     headline: frontmatter.title,
     description: frontmatter.summary ?? undefined,
     inLanguage: 'en',
-    url: `/learn/${params.slug}`,
+    url: `${siteUrl}/learn/${params.slug}`,
     dateModified: frontmatter.updated
       ? new Date(frontmatter.updated).toISOString()
       : undefined,

--- a/app/learn/[slug]/page.tsx
+++ b/app/learn/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from 'next/navigation';
 import { compileMDX } from 'next-mdx-remote/rsc';
+import JsonLd from '@/components/JsonLd';
 import { createMdxComponents } from '@/mdx-components';
 import {
   loadLessonFrontmatter,
@@ -50,6 +51,22 @@ export default async function LessonPage({ params }: { params: { slug: string } 
   const frontmatter = loadLessonFrontmatter(params.slug);
   const { components } = createMdxComponents('en');
 
+  const lessonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'LearningResource',
+    headline: frontmatter.title,
+    description: frontmatter.summary ?? undefined,
+    inLanguage: 'en',
+    url: `/learn/${params.slug}`,
+    dateModified: frontmatter.updated
+      ? new Date(frontmatter.updated).toISOString()
+      : undefined,
+    keywords:
+      Array.isArray(frontmatter.tags) && frontmatter.tags.length > 0
+        ? frontmatter.tags
+        : undefined,
+  } as const;
+
   const { content } = await compileMDX({
     source,
     components,
@@ -73,6 +90,8 @@ export default async function LessonPage({ params }: { params: { slug: string } 
           العربية — قريبًا
         </button>
       </div>
+
+      <JsonLd id={`ld-lesson-${params.slug}`} data={lessonLd} />
 
       <article className="prose prose-sm mt-8 max-w-none prose-a:text-blue-600 hover:prose-a:underline">
         {content}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import type { MetadataRoute } from 'next';
 import { loadChapterFrontmatter, loadChapterSlugsAr, hasArChapter, hasEnChapter } from '@/lib/loaders.chapters';
+import { loadLessonFrontmatter, loadLessonSlugs } from '@/lib/loaders.lessons';
 import { loadGazetteer } from '@/lib/loaders.places';
 import { loadTimelineEvents } from '@/lib/loaders.timeline';
 
@@ -33,10 +34,30 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { url: `${base}/`, lastModified: now, alternates: buildLanguageAlternates(`${base}/`, `${base}/ar`) },
     { url: `${base}/map`, lastModified: now, alternates: buildLanguageAlternates(`${base}/map`, `${base}/ar/map`) },
     { url: `${base}/timeline`, lastModified: now, alternates: buildLanguageAlternates(`${base}/timeline`, `${base}/ar/timeline`) },
+    { url: `${base}/learn`, lastModified: now, alternates: buildLanguageAlternates(`${base}/learn`, `${base}/ar/learn`) },
     { url: `${base}/ar`, lastModified: now, alternates: buildLanguageAlternates(`${base}/`, `${base}/ar`) },
     { url: `${base}/ar/map`, lastModified: now, alternates: buildLanguageAlternates(`${base}/map`, `${base}/ar/map`) },
     { url: `${base}/ar/timeline`, lastModified: now, alternates: buildLanguageAlternates(`${base}/timeline`, `${base}/ar/timeline`) },
+    { url: `${base}/ar/learn`, lastModified: now, alternates: buildLanguageAlternates(`${base}/learn`, `${base}/ar/learn`) },
   ];
+
+  const lessonSlugs = loadLessonSlugs().sort();
+  for (const slug of lessonSlugs) {
+    const { _file } = loadLessonFrontmatter(slug);
+    const lastModified = getFileMtimeIso(_file);
+    const enUrl = `${base}/learn/${slug}`;
+
+    urls.push({
+      url: enUrl,
+      lastModified,
+      alternates: {
+        languages: {
+          en: enUrl,
+          'x-default': enUrl,
+        },
+      },
+    });
+  }
 
   const chapterSlugs = Array.from(new Set(loadChapterSlugsAr())).sort();
   for (const slug of chapterSlugs) {

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -53,6 +53,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
       alternates: {
         languages: {
           en: enUrl,
+          // Lessons currently publish in English only; Arabic translations are forthcoming.
           'x-default': enUrl,
         },
       },

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -116,6 +116,15 @@ const nextConfig = {
           },
         ],
       },
+      {
+        source: '/learn/:slug/opengraph-image',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: openGraphCacheControl,
+          },
+        ],
+      },
     ];
   },
 

--- a/tests/e2e/og.lesson.spec.ts
+++ b/tests/e2e/og.lesson.spec.ts
@@ -1,0 +1,9 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Lesson Open Graph image route', () => {
+  test('serves OG image for introduction lesson', async ({ request }) => {
+    const response = await request.get('/learn/introduction/opengraph-image');
+    expect(response.ok()).toBeTruthy();
+    expect(response.headers()['content-type']).toContain('image/png');
+  });
+});

--- a/tests/e2e/sitemap.spec.ts
+++ b/tests/e2e/sitemap.spec.ts
@@ -13,6 +13,8 @@ test.describe('sitemap.xml', () => {
 
     expect(body).toMatch(/<loc>[^<]+\/map<\/loc>/);
     expect(body).toMatch(/<loc>[^<]+\/ar\/timeline<\/loc>/);
+    expect(body).toMatch(/<loc>[^<]+\/learn<\/loc>/);
+    expect(body).toMatch(/<loc>[^<]+\/ar\/learn<\/loc>/);
 
     const chapterMatches = extractMatches(body, /\/chapters\/[^<]+/g);
     expect(chapterMatches.length).toBeGreaterThan(0);
@@ -20,6 +22,8 @@ test.describe('sitemap.xml', () => {
     const timelineDetailMatches = extractMatches(body, /https?:\/\/[^<]+\/timeline\/[^<]+/g);
     const hasDetail = timelineDetailMatches.some((href) => !href.endsWith('/timeline'));
     expect(hasDetail).toBeTruthy();
+
+    expect(body).toMatch(/<loc>[^<]+\/learn\/introduction<\/loc>/);
 
     const legacyMapRoute = `/${'maps'}`;
     expect(body).not.toContain(legacyMapRoute);

--- a/tests/e2e/structured-data.lesson.spec.ts
+++ b/tests/e2e/structured-data.lesson.spec.ts
@@ -1,0 +1,21 @@
+import type { Page } from '@playwright/test';
+import { expect, test } from '@playwright/test';
+
+async function readLessonJsonLd(page: Page) {
+  const locator = page.locator('script[type="application/ld+json"]');
+  await expect(locator).toHaveCount(1);
+  const text = await locator.first().textContent();
+  return JSON.parse(text ?? '{}');
+}
+
+test.describe('Lesson structured data', () => {
+  test('renders LearningResource schema on introduction lesson', async ({ page }) => {
+    await page.goto('/learn/introduction');
+    const data = await readLessonJsonLd(page);
+
+    expect(data['@type']).toBe('LearningResource');
+    expect(data.inLanguage).toBe('en');
+    expect(data.url).toMatch(/\/learn\/introduction$/);
+    expect(data.dateModified).toBe('2024-05-01T00:00:00.000Z');
+  });
+});


### PR DESCRIPTION
## Summary
- add Learn index and per-lesson URLs with appropriate language alternates and last-modified data to the sitemap
- render LearningResource JSON-LD and supply an Open Graph image route for lesson pages, including cache headers
- extend Playwright coverage for Learn structured data, OG image routing, and sitemap expectations

## Testing
- CI=1 npm run build
- npx playwright test tests/e2e/structured-data.lesson.spec.ts tests/e2e/og.lesson.spec.ts tests/e2e/sitemap.spec.ts *(fails: Playwright browsers unavailable in sandbox; Chromium download blocked with HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_b_690be40502b8832ea17796b4e5e46748