### PR TITLE
chore(privacy): remove @vercel/analytics and @vercel/speed-insights

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ npm run test:e2e    # playwright
   npx playwright install --with-deps
   ```
 
+## Privacy & Analytics
+
+We do not ship proprietary analytics or tracking packages. This follows the anti-surveillance discipline documented in [AGENTS.md](./AGENTS.md). The existing Content Security Policy already blocks third-party trackers, so no additional CSP allowances are required.
+
 ## Private admin interface
 
 The Decap CMS integration has been replaced with a custom admin SPA at `/admin`. The admin surface speaks directly to the GitHub API using server-side helpers and offers two auth modes:

--- a/package.json
+++ b/package.json
@@ -15,8 +15,6 @@
   },
   "dependencies": {
     "@next/mdx": "^16.0.1",
-    "@vercel/analytics": "^1.5.0",
-    "@vercel/speed-insights": "^1.2.0",
     "fuse.js": "^7.1.0",
     "gray-matter": "^4.0.3",
     "leaflet": "^1.9.4",

--- a/tests/unit/privacy-packages.test.ts
+++ b/tests/unit/privacy-packages.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest'
+import pkg from '../../package.json'
+
+describe('privacy: banned runtime packages are absent', () => {
+  const banned = ['@vercel/analytics', '@vercel/speed-insights']
+
+  it('removes proprietary tracking libs from dependencies', () => {
+    const deps = Object.keys(pkg.dependencies ?? {})
+    for (const name of banned) {
+      expect(deps).not.toContain(name)
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- remove @vercel/analytics and @vercel/speed-insights from runtime dependencies
- add a unit test that guards against reintroducing the banned tracking packages
- document the privacy stance in the README so contributors see the anti-surveillance requirement

## Rationale
- aligns dependencies with the anti-surveillance rule in [AGENTS.md](./AGENTS.md#-do-not-use)
- reflects the political discipline described in [AGENTS.md](./AGENTS.md#-politicalmovement-discipline), keeping proprietary telemetry out of the project

## Testing
- npm run test:unit

## Notes
- Lockfiles still reference the removed packages; please regenerate them via CI or a follow-up automation-driven PR.

------
https://chatgpt.com/codex/tasks/task_b_690bf834548c832ea485bf6fc3c79d45