### PR TITLE
Migrate to self-hosted fonts with next/font; remove external font requests; add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ Per the [AGENTS.md](./AGENTS.md) governance guidance, this project does not ship
 All runtime dependencies are screened to keep `@vercel/analytics`, `@vercel/speed-insights`, and similar trackers out of the
 bundle, so our existing Content Security Policy in `next.config.mjs` requires no additional allowances.
 
+- Fonts are self-hosted via [`next/font`](https://nextjs.org/docs/14/app/building-your-application/optimizing/fonts) to avoid
+  requests to Google Fonts, reduce layout shift, and prevent third-party exposure of visitor IP addresses (a risk highlighted by
+  [German case law on Google Fonts](https://externer-datenschutzbeauftragter-dresden.de/en/data-protection/damages-for-disclosure-of-dynamic-ip-address-when-using-google-fonts/)).
+
 ## Private admin interface
 
 The Decap CMS integration has been replaced with a custom admin SPA at `/admin`. The admin surface speaks directly to the GitHub API using server-side helpers and offers two auth modes:

--- a/app/(site)/ar/layout.tsx
+++ b/app/(site)/ar/layout.tsx
@@ -1,7 +1,7 @@
 import '../../globals.css';
 import type { ReactNode } from 'react';
 
-import { inter, naskh } from '@/app/ui/fonts';
+import { interVariable, naskhVariable } from '@/app/ui/fonts';
 
 export const metadata = {
   title: 'فلسطين',
@@ -21,7 +21,11 @@ export const metadata = {
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="ar" dir="rtl" className={`${inter.variable} ${naskh.variable}`}>
+    <html
+      lang="ar"
+      dir="rtl"
+      className={[interVariable, naskhVariable].filter(Boolean).join(' ')}
+    >
       <body className="font-arabic bg-white text-gray-900">
         <a
           href="#main"

--- a/app/(site)/ar/layout.tsx
+++ b/app/(site)/ar/layout.tsx
@@ -1,6 +1,8 @@
 import '../../globals.css';
 import type { ReactNode } from 'react';
 
+import { inter, naskh } from '@/app/ui/fonts';
+
 export const metadata = {
   title: 'فلسطين',
   description: 'تاريخ عام وفني لفلسطين',
@@ -19,7 +21,7 @@ export const metadata = {
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="ar" dir="rtl">
+    <html lang="ar" dir="rtl" className={`${inter.variable} ${naskh.variable}`}>
       <body className="font-arabic bg-white text-gray-900">
         <a
           href="#main"

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,7 +3,7 @@ import './globals.css';
 import type { ReactNode } from 'react';
 import Script from 'next/script';
 
-import { inter, naskh } from '@/app/ui/fonts';
+import { interVariable, naskhVariable } from '@/app/ui/fonts';
 
 const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://palestine-two.vercel.app';
 
@@ -34,7 +34,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
     <html
       lang="en"
       suppressHydrationWarning
-      className={`${inter.variable} ${naskh.variable} no-js`}
+      className={[interVariable, naskhVariable, 'no-js'].filter(Boolean).join(' ')}
     >
       <body className="font-sans">
         <Script id="init-js" strategy="beforeInteractive">

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,8 @@ import './globals.css';
 import type { ReactNode } from 'react';
 import Script from 'next/script';
 
+import { inter, naskh } from '@/app/ui/fonts';
+
 const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://palestine-two.vercel.app';
 
 export const metadata = {
@@ -29,7 +31,11 @@ export const metadata = {
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="en" suppressHydrationWarning className="no-js">
+    <html
+      lang="en"
+      suppressHydrationWarning
+      className={`${inter.variable} ${naskh.variable} no-js`}
+    >
       <body className="font-sans">
         <Script id="init-js" strategy="beforeInteractive">
           {`document.documentElement.classList.remove('no-js');

--- a/app/ui/fonts.ts
+++ b/app/ui/fonts.ts
@@ -3,12 +3,12 @@ import { Inter, Noto_Naskh_Arabic } from 'next/font/google';
 export const inter = Inter({
   subsets: ['latin'],
   display: 'swap',
-  variable: '--font-inter',
+  variable: 'font-inter',
 });
 
 export const naskh = Noto_Naskh_Arabic({
   subsets: ['arabic'],
   weight: ['400', '700'],
   display: 'swap',
-  variable: '--font-naskh',
+  variable: 'font-naskh',
 });

--- a/app/ui/fonts.ts
+++ b/app/ui/fonts.ts
@@ -3,12 +3,16 @@ import { Inter, Noto_Naskh_Arabic } from 'next/font/google';
 export const inter = Inter({
   subsets: ['latin'],
   display: 'swap',
-  variable: 'font-inter',
+  variable: '--font-inter',
 });
+
+export const interVariable = 'variable' in inter ? inter.variable : '';
 
 export const naskh = Noto_Naskh_Arabic({
   subsets: ['arabic'],
   weight: ['400', '700'],
   display: 'swap',
-  variable: 'font-naskh',
+  variable: '--font-naskh',
 });
+
+export const naskhVariable = 'variable' in naskh ? naskh.variable : '';

--- a/app/ui/fonts.ts
+++ b/app/ui/fonts.ts
@@ -1,0 +1,14 @@
+import { Inter, Noto_Naskh_Arabic } from 'next/font/google';
+
+export const inter = Inter({
+  subsets: ['latin'],
+  display: 'swap',
+  variable: '--font-inter',
+});
+
+export const naskh = Noto_Naskh_Arabic({
+  subsets: ['arabic'],
+  weight: ['400', '700'],
+  display: 'swap',
+  variable: '--font-naskh',
+});

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -7,7 +7,26 @@ const config: Config = {
     './content/**/*.{md,mdx}'
   ],
   theme: {
-    extend: {}
+    extend: {
+      fontFamily: {
+        sans: [
+          'var(--font-inter)',
+          'system-ui',
+          '-apple-system',
+          "'Segoe UI'",
+          'Roboto',
+          'Arial',
+          'sans-serif',
+        ],
+        arabic: [
+          'var(--font-naskh)',
+          "'Noto Naskh Arabic'",
+          "'Amiri'",
+          "'Scheherazade New'",
+          'serif',
+        ],
+      },
+    },
   },
   plugins: []
 };

--- a/tests/e2e/no-external-fonts.spec.ts
+++ b/tests/e2e/no-external-fonts.spec.ts
@@ -1,0 +1,29 @@
+import { expect, test } from '@playwright/test';
+
+const bannedHosts = /(fonts\.googleapis\.com|fonts\.gstatic\.com)/i;
+
+async function collectRequests(url: string, page: import('@playwright/test').Page) {
+  const requests: string[] = [];
+  page.on('request', (request) => {
+    requests.push(request.url());
+  });
+  await page.goto(url);
+  await page.waitForLoadState('networkidle');
+  return requests;
+}
+
+test.describe('font privacy', () => {
+  test('english routes avoid Google font hosts', async ({ page }) => {
+    const requests = await collectRequests('/', page);
+
+    const violations = requests.filter((requestUrl) => bannedHosts.test(requestUrl));
+    expect(violations, violations.join('\n')).toHaveLength(0);
+  });
+
+  test('arabic routes avoid Google font hosts', async ({ page }) => {
+    const requests = await collectRequests('/ar', page);
+
+    const violations = requests.filter((requestUrl) => bannedHosts.test(requestUrl));
+    expect(violations, violations.join('\n')).toHaveLength(0);
+  });
+});

--- a/tests/unit/privacy-fonts.test.ts
+++ b/tests/unit/privacy-fonts.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, extname } from 'node:path';
+
+const root = process.cwd();
+const watchedDirectories = ['app', 'components', 'styles'];
+const allowedExtensions = new Set(['.ts', '.tsx', '.js', '.jsx', '.css', '.mdx', '.md', '.html', '.mjs', '.cjs']);
+const bannedPatterns = [/fonts\.googleapis\.com/i, /fonts\.gstatic\.com/i];
+
+describe('privacy: bundle avoids external font hosts', () => {
+  const files: string[] = [];
+
+  for (const directory of watchedDirectories) {
+    const fullPath = join(root, directory);
+    collectFiles(fullPath, files);
+  }
+
+  it('removes Google Fonts links from the codebase', () => {
+    for (const file of files) {
+      if (!allowedExtensions.has(extname(file))) {
+        continue;
+      }
+
+      const contents = readFileSync(file, 'utf8');
+      for (const pattern of bannedPatterns) {
+        expect(contents).not.toMatch(pattern);
+      }
+    }
+  });
+});
+
+function collectFiles(directory: string, accumulator: string[]) {
+  const entries = readdirSync(directory);
+  for (const entry of entries) {
+    const absolute = join(directory, entry);
+    const stats = statSync(absolute);
+
+    if (stats.isDirectory()) {
+      collectFiles(absolute, accumulator);
+      continue;
+    }
+
+    accumulator.push(absolute);
+  }
+}


### PR DESCRIPTION
## Summary
- self-host Inter and Noto Naskh Arabic via `next/font` and wire the font variables into both English and Arabic layouts
- map Tailwind font families to the new CSS variables and document the privacy/performance benefits of self-hosted fonts
- add unit and Playwright safeguards to block regressions that reintroduce Google Fonts requests

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_b_690bff978f488320a2a278fed4b5ec80