### PR TITLE
Add locale-aware navigation and middleware locale rewrites

### DIFF
--- a/app/(site)/ar/layout.tsx
+++ b/app/(site)/ar/layout.tsx
@@ -1,6 +1,7 @@
 import '../../globals.css';
 import type { ReactNode } from 'react';
 
+import { LocaleProvider } from '@/components/LocaleLink';
 import { interVariable, naskhVariable } from '@/app/ui/fonts';
 
 export const metadata = {
@@ -27,13 +28,15 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       className={[interVariable, naskhVariable].filter(Boolean).join(' ')}
     >
       <body className="font-arabic bg-white text-gray-900">
-        <a
-          href="#main"
-          className="sr-only focus:not-sr-only focus:absolute rtl:focus:right-3 ltr:focus:left-3 focus:top-3 focus:z-50 rounded bg-white px-3 py-1 text-sm shadow"
-        >
-          تجاوز إلى المحتوى
-        </a>
-        <div>{children}</div>
+        <LocaleProvider locale="ar">
+          <a
+            href="#main"
+            className="sr-only focus:not-sr-only focus:absolute rtl:focus:right-3 ltr:focus:left-3 focus:top-3 focus:z-50 rounded bg-white px-3 py-1 text-sm shadow"
+          >
+            تجاوز إلى المحتوى
+          </a>
+          <div>{children}</div>
+        </LocaleProvider>
       </body>
     </html>
   );

--- a/app/(site)/ar/learn/page.tsx
+++ b/app/(site)/ar/learn/page.tsx
@@ -1,4 +1,4 @@
-import Link from 'next/link';
+import LocaleLink from '@/components/LocaleLink';
 
 export const metadata = {
   title: 'وحدات تعليمية',
@@ -25,13 +25,16 @@ export default function LearnIndexPageAr() {
       </p>
 
       <div className="mt-6 text-sm text-gray-700" dir="ltr">
-        <Link className="underline hover:no-underline" href="/learn">
+        <LocaleLink className="underline hover:no-underline" href="/learn" locale="en">
           View the English lessons →
-        </Link>
+        </LocaleLink>
       </div>
 
       <p className="mt-10 text-sm text-gray-600">
-        لديك منهج مجتمعي لمشاركته؟ <Link className="underline hover:no-underline" href="/ar/submit">أرسل موادك هنا.</Link>
+        لديك منهج مجتمعي لمشاركته؟{' '}
+        <LocaleLink className="underline hover:no-underline" href="/ar/submit" locale="ar">
+          أرسل موادك هنا.
+        </LocaleLink>
       </p>
     </main>
   );

--- a/app/(site)/ar/not-found.tsx
+++ b/app/(site)/ar/not-found.tsx
@@ -1,4 +1,4 @@
-import Link from 'next/link';
+import LocaleLink from '@/components/LocaleLink';
 
 export default function NotFoundAr() {
   return (
@@ -14,21 +14,23 @@ export default function NotFoundAr() {
         لم نعثر على الصفحة المطلوبة. قد تكون أُزيلت أو نُقلت.
       </p>
       <nav className="flex flex-wrap items-center justify-center gap-4 text-sm font-medium">
-        <Link
+        <LocaleLink
           href="/ar"
+          locale="ar"
           className="rounded px-4 py-2 underline underline-offset-4 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-current"
           aria-label="العودة إلى الصفحة الرئيسية العربية"
         >
           العودة إلى الصفحة الرئيسية
-        </Link>
-        <Link
+        </LocaleLink>
+        <LocaleLink
           href="/"
+          locale="en"
           className="rounded px-4 py-2 underline underline-offset-4 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-current"
           dir="ltr"
           aria-label="View English homepage"
         >
           English
-        </Link>
+        </LocaleLink>
       </nav>
     </main>
   );

--- a/app/ar/error.tsx
+++ b/app/ar/error.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import Link from 'next/link';
 import { useEffect } from 'react';
 
 import FocusHeading from '@/components/FocusHeading';
+import LocaleLink from '@/components/LocaleLink';
 import { interVariable, naskhVariable } from '@/app/ui/fonts';
 
 type GlobalErrorProps = {
@@ -44,18 +44,20 @@ export default function GlobalErrorAr({ error, reset }: GlobalErrorProps) {
             >
               حاول مجددًا
             </button>
-            <Link
+            <LocaleLink
               href="/ar"
+              locale="ar"
               className="rounded border border-transparent px-4 py-2 text-gray-900 underline underline-offset-4 transition hover:text-gray-700"
             >
               العودة إلى الرئيسية
-            </Link>
-            <Link
+            </LocaleLink>
+            <LocaleLink
               href="/ar/timeline"
+              locale="ar"
               className="rounded border border-transparent px-4 py-2 text-gray-900 underline underline-offset-4 transition hover:text-gray-700"
             >
               استكشاف الخط الزمني
-            </Link>
+            </LocaleLink>
           </div>
         </main>
       </body>

--- a/app/ar/not-found.tsx
+++ b/app/ar/not-found.tsx
@@ -1,7 +1,7 @@
-import Link from 'next/link';
 import type { Metadata } from 'next';
 
 import FocusHeading from '@/components/FocusHeading';
+import LocaleLink from '@/components/LocaleLink';
 
 export const metadata: Metadata = {
   title: 'الصفحة غير موجودة — فلسطين',
@@ -19,15 +19,20 @@ export default function NotFoundAr() {
         الصفحة التي تبحث عنها غير موجودة أو ربما تم نقلها. يمكنك الرجوع إلى الصفحة الرئيسية أو استكشاف الخط الزمني.
       </p>
       <nav className="flex flex-wrap items-center justify-center gap-4 text-sm font-medium">
-        <Link href="/ar" className="rounded border border-gray-900 px-4 py-2 text-gray-900 transition hover:bg-gray-900 hover:text-white">
+        <LocaleLink
+          href="/ar"
+          locale="ar"
+          className="rounded border border-gray-900 px-4 py-2 text-gray-900 transition hover:bg-gray-900 hover:text-white"
+        >
           العودة إلى الرئيسية
-        </Link>
-        <Link
+        </LocaleLink>
+        <LocaleLink
           href="/ar/timeline"
+          locale="ar"
           className="rounded px-4 py-2 text-gray-900 underline underline-offset-4 transition hover:text-gray-700"
         >
           استكشاف الخط الزمني
-        </Link>
+        </LocaleLink>
       </nav>
     </main>
   );

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import Link from 'next/link';
 import { useEffect } from 'react';
 
 import FocusHeading from '@/components/FocusHeading';
+import LocaleLink from '@/components/LocaleLink';
 import { interVariable, naskhVariable } from '@/app/ui/fonts';
 
 type GlobalErrorProps = {
@@ -43,18 +43,20 @@ export default function GlobalError({ error, reset }: GlobalErrorProps) {
             >
               Try again
             </button>
-            <Link
+            <LocaleLink
               href="/"
+              locale="en"
               className="rounded border border-transparent px-4 py-2 text-gray-900 underline underline-offset-4 transition hover:text-gray-700"
             >
               Return home
-            </Link>
-            <Link
+            </LocaleLink>
+            <LocaleLink
               href="/timeline"
+              locale="en"
               className="rounded border border-transparent px-4 py-2 text-gray-900 underline underline-offset-4 transition hover:text-gray-700"
             >
               View the timeline
-            </Link>
+            </LocaleLink>
           </div>
         </main>
       </body>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import './globals.css';
 import type { ReactNode } from 'react';
 import Script from 'next/script';
 
+import { LocaleProvider } from '@/components/LocaleLink';
 import { interVariable, naskhVariable } from '@/app/ui/fonts';
 
 const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://palestine-two.vercel.app';
@@ -37,17 +38,19 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       className={[interVariable, naskhVariable, 'no-js'].filter(Boolean).join(' ')}
     >
       <body className="font-sans">
-        <Script id="init-js" strategy="beforeInteractive">
-          {`document.documentElement.classList.remove('no-js');
+        <LocaleProvider locale="en">
+          <Script id="init-js" strategy="beforeInteractive">
+            {`document.documentElement.classList.remove('no-js');
 document.documentElement.classList.add('js-enabled');`}
-        </Script>
-        <a
-          href="#main"
-          className="sr-only focus:not-sr-only focus:absolute focus:left-3 focus:top-3 focus:z-50 rounded bg-white px-3 py-1 text-sm shadow"
-        >
-          Skip to main content
-        </a>
-        {children}
+          </Script>
+          <a
+            href="#main"
+            className="sr-only focus:not-sr-only focus:absolute focus:left-3 focus:top-3 focus:z-50 rounded bg-white px-3 py-1 text-sm shadow"
+          >
+            Skip to main content
+          </a>
+          {children}
+        </LocaleProvider>
       </body>
     </html>
   );

--- a/app/learn/page.tsx
+++ b/app/learn/page.tsx
@@ -1,4 +1,4 @@
-import Link from 'next/link';
+import LocaleLink from '@/components/LocaleLink';
 import { loadLessonFrontmatter, loadLessonSlugs } from '@/lib/loaders.lessons';
 
 export const metadata = {
@@ -32,9 +32,9 @@ export default function LearnIndexPage() {
         {lessons.map((lesson) => (
           <li key={lesson.slug} className="rounded border p-4 shadow-sm">
             <h2 className="text-lg font-semibold">
-              <Link className="underline hover:no-underline" href={`/learn/${lesson.slug}`}>
+              <LocaleLink className="underline hover:no-underline" href={`/learn/${lesson.slug}`} locale="en">
                 {lesson.title}
-              </Link>
+              </LocaleLink>
             </h2>
             {lesson.summary ? <p className="mt-2 text-sm text-gray-700">{lesson.summary}</p> : null}
             {lesson.updated ? (
@@ -45,7 +45,10 @@ export default function LearnIndexPage() {
       </ul>
 
       <p className="mt-10 text-sm text-gray-700">
-        Have a community curriculum to share? <a className="underline hover:no-underline" href="/submit">Propose it here.</a>
+        Have a community curriculum to share?{' '}
+        <LocaleLink className="underline hover:no-underline" href="/submit" locale="en">
+          Propose it here.
+        </LocaleLink>
       </p>
     </main>
   );

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,4 +1,4 @@
-import Link from 'next/link';
+import LocaleLink from '@/components/LocaleLink';
 import type { Metadata } from 'next';
 
 import FocusHeading from '@/components/FocusHeading';
@@ -18,15 +18,20 @@ export default function NotFound() {
         The page you requested does not exist or may have been moved. Please return to the homepage or explore the timeline.
       </p>
       <nav className="flex flex-wrap items-center justify-center gap-4 text-sm font-medium">
-        <Link href="/" className="rounded border border-gray-900 px-4 py-2 text-gray-900 transition hover:bg-gray-900 hover:text-white">
+        <LocaleLink
+          href="/"
+          locale="en"
+          className="rounded border border-gray-900 px-4 py-2 text-gray-900 transition hover:bg-gray-900 hover:text-white"
+        >
           Return home
-        </Link>
-        <Link
+        </LocaleLink>
+        <LocaleLink
           href="/timeline"
+          locale="en"
           className="rounded px-4 py-2 text-gray-900 underline underline-offset-4 transition hover:text-gray-700"
         >
           View the timeline
-        </Link>
+        </LocaleLink>
       </nav>
     </main>
   );

--- a/app/places/[id]/page.tsx
+++ b/app/places/[id]/page.tsx
@@ -1,10 +1,10 @@
 // app/places/[id]/page.tsx
-import Link from 'next/link';
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import JsonLd from '@/components/JsonLd';
 import { loadGazetteer } from '@/lib/loaders.places';
 import { buildLanguageToggleHref } from '@/lib/i18nRoutes';
+import LocaleLink from '@/components/LocaleLink';
 
 export const dynamic = 'force-static';
 
@@ -76,9 +76,13 @@ export default function PlacePage({ params }: { params: { id: string } }) {
       ) : null}
 
       <p className="mt-6 text-sm">
-        <Link className="underline hover:no-underline" href={`/map?place=${encodeURIComponent(p.id)}`}>
+        <LocaleLink
+          className="underline hover:no-underline"
+          href={`/map?place=${encodeURIComponent(p.id)}`}
+          locale="en"
+        >
           View on map →
-        </Link>
+        </LocaleLink>
       </p>
 
       <p className="mt-8 text-sm text-gray-600">

--- a/components/LanguageSwitcher.tsx
+++ b/components/LanguageSwitcher.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import Link from 'next/link';
 import { usePathname, useSearchParams } from 'next/navigation';
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
+
+import LocaleLink, { type Locale } from '@/components/LocaleLink';
 import { buildLanguageToggleHref } from '@/lib/i18nRoutes';
 
 export default function LanguageSwitcher() {
@@ -10,9 +11,9 @@ export default function LanguageSwitcher() {
   const searchParams = useSearchParams();
   const search = searchParams.toString();
 
-  const { href, label, linkDir, testId } = useMemo(() => {
+  const { href, label, linkDir, testId, targetLocale } = useMemo(() => {
     const isArabic = pathname === '/ar' || pathname.startsWith('/ar/');
-    const targetLocale = isArabic ? 'en' : 'ar';
+    const targetLocale: Locale = isArabic ? 'en' : 'ar';
     const params = search ? new URLSearchParams(search) : undefined;
     const href = buildLanguageToggleHref(pathname || '/', params, targetLocale);
 
@@ -21,17 +22,35 @@ export default function LanguageSwitcher() {
       label: isArabic ? 'English' : 'العربية',
       linkDir: isArabic ? ('ltr' as const) : ('rtl' as const),
       testId: isArabic ? 'language-toggle-en' : 'language-toggle-ar',
+      targetLocale,
     };
   }, [pathname, search]);
 
+  const handleClick = useCallback(() => {
+    const maxAge = 60 * 60 * 24 * 180; // roughly 180 days
+    const secure = process.env.NODE_ENV === 'production';
+    const cookieParts = [
+      `p2_locale=${encodeURIComponent(targetLocale)}`,
+      `Max-Age=${maxAge}`,
+      'Path=/',
+      'SameSite=Lax',
+    ];
+    if (secure) {
+      cookieParts.push('Secure');
+    }
+    document.cookie = cookieParts.join('; ');
+  }, [targetLocale]);
+
   return (
-    <Link
+    <LocaleLink
       href={href}
+      locale={targetLocale}
       className="text-sm font-semibold underline decoration-dotted underline-offset-4 hover:no-underline"
       dir={linkDir}
       data-testid={testId}
+      onClick={handleClick}
     >
       {label}
-    </Link>
+    </LocaleLink>
   );
 }

--- a/components/LocaleLink.tsx
+++ b/components/LocaleLink.tsx
@@ -1,0 +1,101 @@
+import Link, { type LinkProps } from 'next/link';
+import type { UrlObject } from 'url';
+import {
+  createContext,
+  useContext,
+  type ComponentPropsWithoutRef,
+  type PropsWithChildren,
+} from 'react';
+
+export type Locale = 'en' | 'ar';
+
+const LocaleContext = createContext<Locale>('en');
+
+export function LocaleProvider({ locale, children }: PropsWithChildren<{ locale: Locale }>) {
+  return <LocaleContext.Provider value={locale}>{children}</LocaleContext.Provider>;
+}
+
+function isRelativeHref(href: string): boolean {
+  if (!href) return false;
+  const trimmed = href.trim();
+  if (!trimmed) return false;
+  if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) return false;
+  if (trimmed.startsWith('mailto:') || trimmed.startsWith('tel:')) return false;
+  if (trimmed.startsWith('#')) return false;
+  if (trimmed.startsWith('//')) return false;
+  return trimmed.startsWith('/');
+}
+
+const localePrefixes: Record<Locale, string> = {
+  en: '/en',
+  ar: '/ar',
+};
+
+function hasLocalePrefix(pathname: string): boolean {
+  return pathname === '/en' || pathname.startsWith('/en/') || pathname === '/ar' || pathname.startsWith('/ar/');
+}
+
+function ensureLeadingSlash(pathname: string): string {
+  if (!pathname) return '/';
+  return pathname.startsWith('/') ? pathname : `/${pathname}`;
+}
+
+export function resolveLocalePath(pathname: string, locale: Locale): string {
+  const normalised = pathname.trim();
+  const withSlash = ensureLeadingSlash(normalised);
+  if (hasLocalePrefix(withSlash)) {
+    return withSlash;
+  }
+  if (withSlash === '/' || withSlash === '') {
+    return localePrefixes[locale];
+  }
+  return `${localePrefixes[locale]}${withSlash}`;
+}
+
+function mapObjectHref(href: UrlObject, locale: Locale): UrlObject {
+  const nextHref: UrlObject = { ...href };
+  if (nextHref.pathname) {
+    nextHref.pathname = resolveLocalePath(String(nextHref.pathname), locale);
+  } else {
+    nextHref.pathname = localePrefixes[locale];
+  }
+  return nextHref;
+}
+
+export function resolveLocaleHref(href: LinkProps['href'], locale: Locale): LinkProps['href'] {
+  if (typeof href === 'string') {
+    const trimmed = href.trim();
+    if (!isRelativeHref(trimmed)) {
+      return href;
+    }
+    try {
+      const url = new URL(trimmed, 'https://palestine.local');
+      const prefixedPath = resolveLocalePath(url.pathname, locale);
+      return `${prefixedPath}${url.search}${url.hash}`;
+    } catch {
+      const [path, rest] = trimmed.split(/(?=[?#])/);
+      const prefixedPath = resolveLocalePath(path, locale);
+      return `${prefixedPath}${rest ?? ''}`;
+    }
+  }
+
+  if (href instanceof URL) {
+    const cloned = new URL(href.toString());
+    cloned.pathname = resolveLocalePath(cloned.pathname, locale);
+    return cloned;
+  }
+
+  return mapObjectHref(href, locale);
+}
+
+type LocaleLinkProps = Omit<ComponentPropsWithoutRef<typeof Link>, 'href'> & {
+  href: LinkProps['href'];
+  locale?: Locale;
+};
+
+export default function LocaleLink({ href, locale, ...rest }: LocaleLinkProps) {
+  const contextLocale = useContext(LocaleContext);
+  const activeLocale = locale ?? contextLocale ?? 'en';
+  const resolvedHref = resolveLocaleHref(href, activeLocale);
+  return <Link {...rest} href={resolvedHref} />;
+}

--- a/components/LocaleLink.tsx
+++ b/components/LocaleLink.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Link, { type LinkProps } from 'next/link';
 import type { UrlObject } from 'url';
 import {

--- a/components/SearchClient.tsx
+++ b/components/SearchClient.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { Fragment, useEffect, useId, useMemo, useState, type ReactNode } from 'react';
-import Link from 'next/link';
+
+import LocaleLink from '@/components/LocaleLink';
 import { buildSearchIndex, searchIndex, type QueryOptions, type SearchIndex } from '@/lib/search';
 import { normalizeSearchDocs } from '@/lib/search-normalize';
 import type { SearchDoc } from '@/lib/search.types';
@@ -253,8 +254,9 @@ export default function SearchClient({ locale = 'en' }: Props) {
               key={doc.id}
               className="rounded border p-3 hover:bg-gray-50 focus-within:ring-2 focus-within:ring-gray-900 focus-within:ring-offset-2 focus-within:ring-offset-white"
             >
-              <Link
+              <LocaleLink
                 href={doc.href}
+                locale={locale}
                 className="block focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-900 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
               >
                 <div className="flex items-start justify-between gap-3">
@@ -275,7 +277,7 @@ export default function SearchClient({ locale = 'en' }: Props) {
                 {doc.tags?.length ? (
                   <p className="mt-2 text-xs text-gray-700">#{doc.tags.join(' #')}</p>
                 ) : null}
-              </Link>
+              </LocaleLink>
             </li>
           );
         })}

--- a/components/Timeline.tsx
+++ b/components/Timeline.tsx
@@ -1,4 +1,4 @@
-import Link from 'next/link';
+import LocaleLink from '@/components/LocaleLink';
 import type { TimelineEvent, Era } from '@/lib/types';
 
 function yearOf(d: string | number | undefined): string {
@@ -62,13 +62,14 @@ export default function Timeline({
             </p>
           )}
           <div className="mt-3 text-xs font-medium">
-            <Link
+            <LocaleLink
               href={t.href(e.id)}
               className="underline hover:no-underline"
               aria-label={t.aria(e.title)}
+              locale={locale}
             >
               {t.details} →
-            </Link>
+            </LocaleLink>
           </div>
         </div>
       ))}

--- a/components/TimelineEventDetail.tsx
+++ b/components/TimelineEventDetail.tsx
@@ -95,11 +95,7 @@ export default function TimelineEventDetail({ event, locale = 'en' }: Props) {
       lang={isArabic ? 'ar' : undefined}
     >
       <p className="text-sm text-gray-600">
-        <LocaleLink
-          className="underline hover:no-underline"
-          href={isArabic ? '/ar/timeline' : '/timeline'}
-          locale={locale}
-        >
+        <LocaleLink className="underline hover:no-underline" href="/timeline" locale={locale}>
           {t.returnLink}
         </LocaleLink>
       </p>
@@ -152,18 +148,10 @@ export default function TimelineEventDetail({ event, locale = 'en' }: Props) {
               const match = placesIndex.get(key);
               const primaryLabel = match ? (isArabic ? match.name_ar ?? match.name : match.name) : raw;
               const placeId = match?.id;
-              const placeHref = placeId
-                ? isArabic
-                  ? `/ar/places/${placeId}`
-                  : `/places/${placeId}`
-                : null;
-              const altHref = placeId
-                ? isArabic
-                  ? `/places/${placeId}`
-                  : `/ar/places/${placeId}`
-                : null;
-              const mapBase = isArabic ? '/ar/map' : '/map';
-              const mapHref = placeId ? `${mapBase}?place=${encodeURIComponent(placeId)}` : null;
+              const placeHref = placeId ? `/places/${placeId}` : null;
+              const altHref = placeId ? `/places/${placeId}` : null;
+              const altLocale = isArabic ? 'en' : 'ar';
+              const mapHref = placeId ? `/map?place=${encodeURIComponent(placeId)}` : null;
 
               return (
                 <li key={raw} className={isArabic ? 'font-arabic space-y-1' : 'space-y-1'}>
@@ -190,7 +178,11 @@ export default function TimelineEventDetail({ event, locale = 'en' }: Props) {
                         {t.viewOnMap} →
                       </LocaleLink>
                       {altHref ? (
-                        <LocaleLink className="underline hover:no-underline" href={altHref} locale={locale}>
+                        <LocaleLink
+                          className="underline hover:no-underline"
+                          href={altHref}
+                          locale={altLocale}
+                        >
                           {t.viewPlaceAlt}
                         </LocaleLink>
                       ) : null}
@@ -208,7 +200,7 @@ export default function TimelineEventDetail({ event, locale = 'en' }: Props) {
           <h2 className="text-sm font-semibold text-gray-700">{t.related}</h2>
           <ul className="space-y-2 text-sm">
             {related.map((item) => {
-              const href = isArabic ? `/ar/timeline/${item.id}` : `/timeline/${item.id}`;
+              const href = `/timeline/${item.id}`;
               return (
                 <li key={item.id}>
                   <LocaleLink className="underline hover:no-underline" href={href} locale={locale}>

--- a/components/TimelineEventDetail.tsx
+++ b/components/TimelineEventDetail.tsx
@@ -1,4 +1,4 @@
-import Link from 'next/link';
+import LocaleLink from '@/components/LocaleLink';
 import { loadEras, getRelatedTimelineEvents } from '@/lib/loaders.timeline';
 import { loadGazetteer } from '@/lib/loaders.places';
 import type { TimelineEvent } from '@/lib/types';
@@ -95,9 +95,13 @@ export default function TimelineEventDetail({ event, locale = 'en' }: Props) {
       lang={isArabic ? 'ar' : undefined}
     >
       <p className="text-sm text-gray-600">
-        <Link className="underline hover:no-underline" href={isArabic ? '/ar/timeline' : '/timeline'}>
+        <LocaleLink
+          className="underline hover:no-underline"
+          href={isArabic ? '/ar/timeline' : '/timeline'}
+          locale={locale}
+        >
           {t.returnLink}
-        </Link>
+        </LocaleLink>
       </p>
 
       <header className={isArabic ? 'font-arabic space-y-2 text-right' : 'space-y-2'}>
@@ -164,16 +168,16 @@ export default function TimelineEventDetail({ event, locale = 'en' }: Props) {
               return (
                 <li key={raw} className={isArabic ? 'font-arabic space-y-1' : 'space-y-1'}>
                   {placeHref ? (
-                    <Link className="underline hover:no-underline" href={placeHref}>
+                    <LocaleLink className="underline hover:no-underline" href={placeHref} locale={locale}>
                       {primaryLabel}
-                    </Link>
+                    </LocaleLink>
                   ) : (
                     <span>{primaryLabel}</span>
                   )}
 
                   {mapHref ? (
                     <div className="flex flex-wrap items-center gap-3 text-xs text-gray-600">
-                      <Link
+                      <LocaleLink
                         className="underline hover:no-underline"
                         href={mapHref}
                         aria-label={
@@ -181,13 +185,14 @@ export default function TimelineEventDetail({ event, locale = 'en' }: Props) {
                             ? `عرض ${primaryLabel} على الخريطة`
                             : `View ${primaryLabel} on the map`
                         }
+                        locale={locale}
                       >
                         {t.viewOnMap} →
-                      </Link>
+                      </LocaleLink>
                       {altHref ? (
-                        <Link className="underline hover:no-underline" href={altHref}>
+                        <LocaleLink className="underline hover:no-underline" href={altHref} locale={locale}>
                           {t.viewPlaceAlt}
-                        </Link>
+                        </LocaleLink>
                       ) : null}
                     </div>
                   ) : null}
@@ -206,9 +211,9 @@ export default function TimelineEventDetail({ event, locale = 'en' }: Props) {
               const href = isArabic ? `/ar/timeline/${item.id}` : `/timeline/${item.id}`;
               return (
                 <li key={item.id}>
-                  <Link className="underline hover:no-underline" href={href}>
+                  <LocaleLink className="underline hover:no-underline" href={href} locale={locale}>
                     {item.title}
-                  </Link>
+                  </LocaleLink>
                 </li>
               );
             })}

--- a/middleware.ts
+++ b/middleware.ts
@@ -2,12 +2,31 @@ import { NextResponse, type NextRequest } from 'next/server';
 
 import { requireBasicAuth } from '@/lib/auth';
 
+const SUPPORTED_LOCALES = new Set(['en', 'ar']);
+const DEFAULT_LOCALE = 'en';
+
+function resolveLocaleFromCookie(req: NextRequest): 'en' | 'ar' {
+  const raw = req.cookies.get('p2_locale')?.value?.toLowerCase();
+  if (raw && SUPPORTED_LOCALES.has(raw)) {
+    return raw as 'en' | 'ar';
+  }
+  return DEFAULT_LOCALE;
+}
+
 export const config = {
-  matcher: ['/admin', '/admin/:path*', '/api/cms/:path*', '/api/admin/:path*'],
+  matcher: ['/', '/admin', '/admin/:path*', '/api/cms/:path*', '/api/admin/:path*'],
 };
 
 export function middleware(req: NextRequest) {
   const { pathname } = req.nextUrl;
+
+  if (pathname === '/') {
+    const targetLocale = resolveLocaleFromCookie(req);
+    const url = req.nextUrl.clone();
+    url.pathname = `/${targetLocale}`;
+    return NextResponse.rewrite(url);
+  }
+
   const isAdminPage = pathname === '/admin' || pathname.startsWith('/admin/');
   const isCmsApiRoute = pathname.startsWith('/api/cms');
   const isAdminApiRoute = pathname.startsWith('/api/admin');

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -161,7 +161,11 @@ const nextConfig = {
 
   // Keep the private CMS shell reachable at /admin → static HTML
   async rewrites() {
-    return [{ source: '/admin', destination: '/admin/index.html' }];
+    return [
+      { source: '/admin', destination: '/admin/index.html' },
+      { source: '/en', destination: '/' },
+      { source: '/en/:path*', destination: '/:path*' },
+    ];
   },
 
   // Preserve legacy map URLs so old links don’t 404

--- a/tests/unit/locale-link.test.ts
+++ b/tests/unit/locale-link.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveLocaleHref, resolveLocalePath } from '@/components/LocaleLink';
+
+describe('resolveLocalePath', () => {
+  it('prefixes english routes with /en', () => {
+    expect(resolveLocalePath('/', 'en')).toBe('/en');
+    expect(resolveLocalePath('/timeline', 'en')).toBe('/en/timeline');
+  });
+
+  it('prefixes arabic routes with /ar', () => {
+    expect(resolveLocalePath('/', 'ar')).toBe('/ar');
+    expect(resolveLocalePath('/timeline', 'ar')).toBe('/ar/timeline');
+  });
+
+  it('preserves existing locale prefixes', () => {
+    expect(resolveLocalePath('/ar/map', 'ar')).toBe('/ar/map');
+    expect(resolveLocalePath('/en/learn', 'en')).toBe('/en/learn');
+  });
+});
+
+describe('resolveLocaleHref', () => {
+  it('adds locale prefix to relative string hrefs', () => {
+    expect(resolveLocaleHref('/timeline', 'en')).toBe('/en/timeline');
+    expect(resolveLocaleHref('/timeline', 'ar')).toBe('/ar/timeline');
+  });
+
+  it('preserves query strings and hashes for relative hrefs', () => {
+    expect(resolveLocaleHref('/map?place=haifa#details', 'ar')).toBe('/ar/map?place=haifa#details');
+  });
+
+  it('leaves external URLs untouched', () => {
+    const external = 'https://example.com/page';
+    expect(resolveLocaleHref(external, 'en')).toBe(external);
+  });
+
+  it('handles UrlObject inputs', () => {
+    const href = { pathname: '/places/haifa', query: { view: 'map' } };
+    const result = resolveLocaleHref(href, 'ar');
+    expect(result).toEqual({ pathname: '/ar/places/haifa', query: { view: 'map' } });
+  });
+});

--- a/tests/unit/middleware.test.ts
+++ b/tests/unit/middleware.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { NextRequest } from 'next/server';
+
+import { middleware } from '@/middleware';
+
+function createRequest(path: string, cookie?: string) {
+  const url = new URL(path, 'https://example.com');
+  const headers = cookie ? new Headers({ cookie }) : undefined;
+  return new NextRequest(url, { headers });
+}
+
+describe('middleware locale cookie handling', () => {
+  it('rewrites / to the arabic locale when cookie is ar', () => {
+    const request = createRequest('/', 'p2_locale=ar');
+    const response = middleware(request);
+    expect(response?.headers.get('x-middleware-rewrite')).toBe('https://example.com/ar');
+  });
+
+  it('rewrites / to /en when cookie is en', () => {
+    const request = createRequest('/', 'p2_locale=en');
+    const response = middleware(request);
+    expect(response?.headers.get('x-middleware-rewrite')).toBe('https://example.com/en');
+  });
+
+  it('defaults to /en when cookie is missing or invalid', () => {
+    const missingCookieReq = createRequest('/');
+    const missingResponse = middleware(missingCookieReq);
+    expect(missingResponse?.headers.get('x-middleware-rewrite')).toBe('https://example.com/en');
+
+    const invalidReq = createRequest('/', 'p2_locale=fr');
+    const invalidResponse = middleware(invalidReq);
+    expect(invalidResponse?.headers.get('x-middleware-rewrite')).toBe('https://example.com/en');
+  });
+
+  it('does not rewrite non-root paths', () => {
+    const request = createRequest('/timeline');
+    const response = middleware(request);
+    expect(response?.headers.get('x-middleware-rewrite')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add a LocaleLink component and provider to derive locale-aware hrefs
- persist language choice with a p2_locale cookie, wrap layouts with the provider, and swap existing navigation to use LocaleLink
- rewrite the root path according to the locale cookie, add supporting tests, and proxy /en paths back to the default routes

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_b_690c30c6d108832e867439e8c495d9fc