### PR TITLE
Enhance map accessibility and announce interactions

### DIFF
--- a/app/(site)/ar/map/page.tsx
+++ b/app/(site)/ar/map/page.tsx
@@ -2,6 +2,7 @@
 import { loadGazetteer } from '@/lib/loaders.places';
 import { loadMapConfig } from '@/lib/loaders.config';
 import MapsPageClientAr from '@/components/MapsPageClient.ar';
+import { AnnouncerProvider } from '@/components/Announcer';
 import { buildLanguageToggleHref } from '@/lib/i18nRoutes';
 
 export const metadata = {
@@ -36,6 +37,12 @@ export default function MapsPageAr({
 
   return (
     <main id="main" tabIndex={-1} className="mx-auto max-w-3xl px-4 py-12" dir="rtl">
+      <a
+        href="#map-places-region-ar"
+        className="sr-only focus:not-sr-only focus:absolute focus:right-3 focus:top-3 focus:z-40 rounded bg-white px-3 py-1 text-sm shadow"
+      >
+        تجاوز إلى قائمة الأماكن
+      </a>
       <h1 className="text-2xl font-semibold tracking-tight">الأماكن</h1>
 
       {/* يظهر فقط عندما تكون JavaScript معطّلة */}
@@ -76,7 +83,9 @@ export default function MapsPageAr({
         </div>
       </noscript>
 
-      <MapsPageClientAr places={places} cfg={cfg} initialFocusId={initialFocusId} />
+      <AnnouncerProvider>
+        <MapsPageClientAr places={places} cfg={cfg} initialFocusId={initialFocusId} />
+      </AnnouncerProvider>
 
       <p className="mt-8 text-sm text-gray-600">
         <a className="underline hover:no-underline" href={enHref} dir="ltr">

--- a/app/map/page.tsx
+++ b/app/map/page.tsx
@@ -2,6 +2,7 @@
 import { loadGazetteer } from '@/lib/loaders.places';
 import { loadMapConfig } from '@/lib/loaders.config';
 import MapsPageClient from '@/components/MapsPageClient';
+import { AnnouncerProvider } from '@/components/Announcer';
 import { buildLanguageToggleHref } from '@/lib/i18nRoutes';
 
 export const metadata = {
@@ -36,6 +37,12 @@ export default function MapsPage({
 
   return (
     <main id="main" tabIndex={-1} className="mx-auto max-w-3xl px-4 py-12">
+      <a
+        href="#map-places-region"
+        className="sr-only focus:not-sr-only focus:absolute focus:left-3 focus:top-3 focus:z-40 rounded bg-white px-3 py-1 text-sm shadow"
+      >
+        Skip to places list
+      </a>
       <h1 className="text-2xl font-semibold tracking-tight">Places</h1>
 
       {/* Rendered only when JS is disabled */}
@@ -80,7 +87,9 @@ export default function MapsPage({
         Loaded from <code>data/gazetteer.json</code>
       </p>
 
-      <MapsPageClient places={places} cfg={cfg} initialFocusId={initialFocusId} />
+      <AnnouncerProvider>
+        <MapsPageClient places={places} cfg={cfg} initialFocusId={initialFocusId} />
+      </AnnouncerProvider>
 
       <p className="mt-8 text-sm text-gray-600">
         <a

--- a/components/Announcer.tsx
+++ b/components/Announcer.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+
+type AnnouncementTone = 'info' | 'success' | 'error';
+
+type Announcement = {
+  id: number;
+  message: string;
+  tone: AnnouncementTone;
+};
+
+type AnnounceOptions = {
+  message: string;
+  tone?: AnnouncementTone;
+};
+
+type AnnouncerContextValue = {
+  announce: (options: AnnounceOptions) => void;
+};
+
+const AnnouncerContext = createContext<AnnouncerContextValue | null>(null);
+
+const toneClasses: Record<AnnouncementTone, string> = {
+  info: 'bg-gray-900 text-white',
+  success: 'bg-green-600 text-white',
+  error: 'bg-red-600 text-white',
+};
+
+export function AnnouncerProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<Announcement[]>([]);
+  const [liveMessage, setLiveMessage] = useState('');
+  const counterRef = useRef(0);
+
+  const announce = useCallback(({ message, tone = 'info' }: AnnounceOptions) => {
+    if (!message) return;
+    counterRef.current += 1;
+    const id = counterRef.current;
+    const announcement: Announcement = { id, message, tone };
+
+    setLiveMessage(message);
+    setToasts((current) => [...current, announcement]);
+
+    window.setTimeout(() => {
+      setToasts((current) => current.filter((toast) => toast.id !== id));
+    }, 3200);
+  }, []);
+
+  const contextValue = useMemo(() => ({ announce }), [announce]);
+
+  return (
+    <AnnouncerContext.Provider value={contextValue}>
+      {children}
+      <div aria-live="polite" role="status" className="sr-only">
+        {liveMessage}
+      </div>
+      <div
+        aria-hidden="true"
+        className="fixed bottom-4 right-4 flex flex-col items-end gap-2"
+      >
+        {toasts.map((toast) => (
+          <div
+            key={toast.id}
+            className={`max-w-sm rounded px-3 py-2 text-sm shadow-lg ${toneClasses[toast.tone]}`}
+          >
+            {toast.message}
+          </div>
+        ))}
+      </div>
+    </AnnouncerContext.Provider>
+  );
+}
+
+export function useAnnouncer() {
+  const ctx = useContext(AnnouncerContext);
+  if (!ctx) {
+    throw new Error('useAnnouncer must be used within an AnnouncerProvider');
+  }
+  return ctx;
+}

--- a/components/MapsPageClient.ar.tsx
+++ b/components/MapsPageClient.ar.tsx
@@ -1,7 +1,10 @@
 'use client';
 
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useId } from 'react';
 import dynamic from 'next/dynamic';
+
+import { useAnnouncer } from './Announcer';
 
 // Load MapClient only on the client so SSR never touches Leaflet/window.
 const MapClient = dynamic(() => import('./MapClient'), { ssr: false });
@@ -27,15 +30,17 @@ type Cfg = {
 function isArabic(s: string) {
   return /[\u0600-\u06FF]/.test(s);
 }
+
 function displayName(p: Place) {
   const ar = p.alt_names?.find(isArabic);
   return ar ?? p.name;
 }
+
 function formatKindAr(kind?: string) {
   if (!kind) return '';
   const m: Record<string, string> = {
     city: 'مدينة',
-    port_city: 'مدينة ساحلية'
+    port_city: 'مدينة ساحلية',
   };
   return m[kind] ?? kind.replace(/_/g, ' ');
 }
@@ -43,7 +48,7 @@ function formatKindAr(kind?: string) {
 export default function MapsPageClientAr({
   places,
   cfg,
-  initialFocusId
+  initialFocusId,
 }: {
   places: Place[];
   cfg: Cfg;
@@ -51,10 +56,18 @@ export default function MapsPageClientAr({
 }) {
   const [focusId, setFocusId] = useState<string | null>(initialFocusId ?? null);
   const [fitTrigger, setFitTrigger] = useState(0);
-  const [copied, setCopied] = useState(false);
-  const [copyMessage, setCopyMessage] = useState('');
+  const [mode, setMode] = useState<'map' | 'list'>('map');
   const [focusAnnouncement, setFocusAnnouncement] = useState('');
-  const copyTimer = useRef<number | null>(null);
+  const mapRegionHeadingId = useId();
+  const listRegionHeadingId = useId();
+  const listRegionId = 'map-places-region-ar';
+  const mapContainerRef = useRef<HTMLDivElement | null>(null);
+  const listContainerRef = useRef<HTMLUListElement | null>(null);
+  const { announce } = useAnnouncer();
+
+  const setMapContainer = useCallback((el: HTMLDivElement | null) => {
+    mapContainerRef.current = el;
+  }, []);
 
   useEffect(() => {
     if (!initialFocusId) return;
@@ -63,7 +76,6 @@ export default function MapsPageClientAr({
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
-    setCopied(false);
     const url = new URL(window.location.href);
     if (focusId) url.searchParams.set('place', focusId);
     else url.searchParams.delete('place');
@@ -75,7 +87,10 @@ export default function MapsPageClientAr({
     return p ? { lat: p.lat, lon: p.lon } : null;
   }, [focusId, places]);
 
-  const focusPlace = useMemo(() => places.find((x) => x.id === focusId) ?? null, [focusId, places]);
+  const focusPlace = useMemo(
+    () => places.find((x) => x.id === focusId) ?? null,
+    [focusId, places]
+  );
 
   const localizedPlaces = useMemo(
     () =>
@@ -95,150 +110,224 @@ export default function MapsPageClientAr({
     setFocusAnnouncement(`تم التركيز على ${label}`);
   }, [focusId, focusPlace]);
 
-  useEffect(() => {
-    return () => {
-      if (copyTimer.current) {
-        window.clearTimeout(copyTimer.current);
-      }
-    };
+  const mapStatus = useMemo(() => {
+    const total = places.length;
+    const modeLabel = mode === 'map' ? 'عرض الخريطة' : 'عرض القائمة';
+    return `${modeLabel}. عرض ${total} مكانًا.`;
+  }, [mode, places.length]);
+
+  const handleShowMap = useCallback(() => {
+    setMode('map');
+    requestAnimationFrame(() => {
+      mapContainerRef.current?.focus();
+    });
   }, []);
 
-  async function copyLink() {
-    if (typeof window === 'undefined') return;
-    try {
-      await navigator.clipboard.writeText(window.location.href);
-      setCopied(true);
-      setCopyMessage('تم نسخ الرابط');
-      if (copyTimer.current) window.clearTimeout(copyTimer.current);
-      copyTimer.current = window.setTimeout(() => {
-        setCopied(false);
-        setCopyMessage('');
-      }, 2500);
-    } catch {
-      setCopied(false);
-      setCopyMessage('');
-    }
-  }
+  const handleShowList = useCallback(() => {
+    setMode('list');
+    requestAnimationFrame(() => {
+      listContainerRef.current?.focus();
+    });
+  }, []);
 
-  const liveAnnouncement = useMemo(() => {
-    return [focusAnnouncement, copyMessage].filter(Boolean).join('؛ ');
-  }, [focusAnnouncement, copyMessage]);
+  const copyLink = useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    const url = window.location.href;
+    try {
+      if (!navigator.clipboard || typeof navigator.clipboard.writeText !== 'function') {
+        throw new Error('clipboard-unavailable');
+      }
+      await navigator.clipboard.writeText(url);
+      announce({ message: 'تم نسخ الرابط إلى الحافظة', tone: 'success' });
+    } catch (error) {
+      try {
+        const manualCopy = window.prompt('انسخ هذا الرابط', url);
+        if (manualCopy !== null) {
+          announce({ message: 'انسخ الرابط المحدد يدويًا.', tone: 'info' });
+          return;
+        }
+      } catch {}
+      announce({
+        message: 'فشل النسخ. انسخ الرابط من شريط العنوان.',
+        tone: 'error',
+      });
+    }
+  }, [announce]);
+
+  const handleFocusMap = useCallback(() => {
+    mapContainerRef.current?.focus();
+  }, []);
 
   return (
     <>
-      <div className="mt-6">
-        <MapClient
-          center={cfg.center}
-          zoom={cfg.zoom}
-          minZoom={cfg.minZoom}
-          maxZoom={cfg.maxZoom}
-          bounds={cfg.bounds}
-          places={localizedPlaces}
-          className="w-full rounded border"
-          focus={focus}
-          fitTrigger={fitTrigger}
-          ariaLabel="خريطة الأماكن الفلسطينية"
-        />
-      </div>
-
-      <div className="mt-4 flex items-center gap-3">
-        <button
-          type="button"
-          className="rounded border px-3 py-1 text-sm hover:bg-gray-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-gray-900 focus-visible:outline-offset-2"
-          onClick={() => setFitTrigger((n) => n + 1)}
-          title="إعادة الضبط لعرض كل الأماكن"
-          aria-label="إعادة الضبط لعرض كل الأماكن"
+      <div className="mt-6 flex flex-col gap-4">
+        <div
+          role="group"
+          aria-label="تغيير العرض"
+          className="inline-flex w-full max-w-xs items-center justify-between rounded border"
         >
-          إعادة الضبط
-        </button>
+          <button
+            type="button"
+            onClick={handleShowMap}
+            className={`flex-1 px-3 py-2 text-sm font-medium focus-visible:outline focus-visible:outline-2 focus-visible:outline-gray-900 focus-visible:outline-offset-2 ${
+              mode === 'map' ? 'bg-gray-900 text-white' : 'bg-white text-gray-900'
+            }`}
+            aria-pressed={mode === 'map'}
+          >
+            عرض الخريطة
+          </button>
+          <button
+            type="button"
+            onClick={handleShowList}
+            className={`flex-1 border-l px-3 py-2 text-sm font-medium focus-visible:outline focus-visible:outline-2 focus-visible:outline-gray-900 focus-visible:outline-offset-2 ${
+              mode === 'list' ? 'bg-gray-900 text-white' : 'bg-white text-gray-900'
+            }`}
+            aria-pressed={mode === 'list'}
+          >
+            عرض القائمة
+          </button>
+        </div>
 
-        <button
-          type="button"
-          className="rounded border px-3 py-1 text-sm hover:bg-gray-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-gray-900 focus-visible:outline-offset-2"
-          onClick={copyLink}
-          title="نسخ رابط قابل للمشاركة"
-          aria-label="نسخ رابط قابل للمشاركة"
+        <p className="text-sm text-gray-600" aria-live="polite" role="status">
+          {mapStatus}
+        </p>
+
+        <section
+          aria-labelledby={mapRegionHeadingId}
+          className={mode === 'map' ? 'block' : 'hidden'}
         >
-          نسخ الرابط
-        </button>
-
-        {copied ? (
-          <span className="text-xs text-green-600">{copyMessage || 'تم نسخ الرابط'}</span>
-        ) : null}
-
-        {focusPlace ? (
-          <span className="text-sm text-gray-600">
-            المركّز: <strong>{displayName(focusPlace)}</strong>
-          </span>
-        ) : focusId ? (
-          <span className="text-sm text-gray-600">
-            المركّز: <code className="ltr:ml-1 rtl:mr-1">{focusId}</code>
-          </span>
-        ) : null}
-      </div>
-
-      <h2 className="sr-only" id="map-places-heading">
-        قائمة الأماكن
-      </h2>
-      <ul
-        aria-labelledby="map-places-heading"
-        className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2"
-      >
-        {places.map((p) => {
-          const focused = p.id === focusId;
-          return (
-            <li
-              key={p.id}
-              className={`place-card rounded border p-3 transition-shadow ${
-                focused ? 'border-gray-900 bg-yellow-100 shadow-inner' : 'hover:bg-gray-50'
-              }`}
-              data-selected={focused ? 'true' : 'false'}
-              aria-selected={focused}
-            >
+          <div className="flex items-center justify-between">
+            <h2 id={mapRegionHeadingId} className="text-lg font-semibold">
+              عرض الخريطة
+            </h2>
+            <div className="flex items-center gap-2">
               <button
                 type="button"
-                className="block w-full text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-gray-900 focus-visible:outline-offset-2"
-                onClick={() => setFocusId(p.id)}
-                aria-pressed={focused}
-                aria-label={`التركيز على ${displayName(p)} في الخريطة`}
-                title="انقر للتركيز على الخريطة"
+                className="rounded border px-3 py-1 text-sm hover:bg-gray-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-gray-900 focus-visible:outline-offset-2"
+                onClick={() => setFitTrigger((n) => n + 1)}
+                title="إعادة الضبط لعرض كل الأماكن"
+                aria-label="إعادة الضبط لعرض كل الأماكن"
               >
-                <div className="font-medium">{displayName(p)}</div>
-                <div className="text-sm text-gray-700">
-                  {formatKindAr(p.kind)} · {p.lat.toFixed(3)}, {p.lon.toFixed(3)}
-                </div>
-                {p.alt_names?.length ? (
-                  <div className="text-xs text-gray-700 mt-1">
-                    أسماء أخرى: {p.alt_names.join('، ')}
-                  </div>
-                ) : null}
+                إعادة الضبط
               </button>
-              <div className="mt-2 flex flex-wrap gap-3 text-xs text-gray-700">
-                <a
-                  href={`/ar/places/${p.id}`}
-                  className="underline hover:no-underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-gray-900 focus-visible:outline-offset-2"
-                  aria-label={`فتح صفحة المكان ${displayName(p)}`}
-                  title="فتح صفحة المكان"
-                >
-                  فتح صفحة المكان →
-                </a>
+              <button
+                type="button"
+                className="rounded border px-3 py-1 text-sm hover:bg-gray-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-gray-900 focus-visible:outline-offset-2"
+                onClick={handleFocusMap}
+              >
+                تركيز الخريطة
+              </button>
+              <button
+                type="button"
+                className="rounded border px-3 py-1 text-sm hover:bg-gray-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-gray-900 focus-visible:outline-offset-2"
+                onClick={copyLink}
+                title="نسخ رابط قابل للمشاركة"
+                aria-label="نسخ رابط قابل للمشاركة"
+              >
+                نسخ الرابط
+              </button>
+            </div>
+          </div>
+
+          <div className="mt-3">
+            <MapClient
+              center={cfg.center}
+              zoom={cfg.zoom}
+              minZoom={cfg.minZoom}
+              maxZoom={cfg.maxZoom}
+              bounds={cfg.bounds}
+              places={localizedPlaces}
+              className="w-full rounded border"
+              focus={focus}
+              fitTrigger={fitTrigger}
+              ariaLabel="خريطة الأماكن الفلسطينية"
+              ariaLabelledBy={mapRegionHeadingId}
+              onContainerReady={setMapContainer}
+            />
+          </div>
+
+          {focusPlace ? (
+            <p className="mt-3 text-sm text-gray-700">
+              المركّز: <strong>{displayName(focusPlace)}</strong>
+            </p>
+          ) : focusId ? (
+            <p className="mt-3 text-sm text-gray-700">
+              المركّز: <code className="ltr:ml-1 rtl:mr-1">{focusId}</code>
+            </p>
+          ) : null}
+        </section>
+      </div>
+
+      <section
+        id={listRegionId}
+        aria-labelledby={listRegionHeadingId}
+        className={`mt-8 ${mode === 'list' ? 'block' : 'hidden'}`}
+      >
+        <h2 id={listRegionHeadingId} className="text-lg font-semibold">
+          قائمة الأماكن
+        </h2>
+        <ul
+          ref={listContainerRef}
+          tabIndex={-1}
+          aria-labelledby={listRegionHeadingId}
+          className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2"
+        >
+          {places.map((p) => {
+            const focused = p.id === focusId;
+            return (
+              <li
+                key={p.id}
+                className={`place-card rounded border p-3 transition-shadow ${
+                  focused ? 'border-gray-900 bg-yellow-100 shadow-inner' : 'hover:bg-gray-50'
+                }`}
+                data-selected={focused ? 'true' : 'false'}
+                aria-selected={focused}
+              >
                 <button
                   type="button"
-                  className="underline hover:no-underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-gray-900 focus-visible:outline-offset-2"
+                  className="block w-full text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-gray-900 focus-visible:outline-offset-2"
                   onClick={() => setFocusId(p.id)}
-                  aria-label={`فتح الخريطة مركّزة على ${displayName(p)}`}
-                  title="فتح الخريطة مركّزة على هذا المكان"
+                  aria-pressed={focused}
+                  aria-label={`التركيز على ${displayName(p)} في الخريطة`}
+                  title="انقر للتركيز على الخريطة"
                 >
-                  فتح على الخريطة
+                  <div className="font-medium">{displayName(p)}</div>
+                  <div className="text-sm text-gray-700">
+                    {formatKindAr(p.kind)} · {p.lat.toFixed(3)}, {p.lon.toFixed(3)}
+                  </div>
+                  {p.alt_names?.length ? (
+                    <div className="text-xs text-gray-700 mt-1">
+                      أسماء أخرى: {p.alt_names.join('، ')}
+                    </div>
+                  ) : null}
                 </button>
-              </div>
-            </li>
-          );
-        })}
-      </ul>
+                <div className="mt-2 flex flex-wrap gap-3 text-xs text-gray-700">
+                  <a
+                    href={`/ar/places/${p.id}`}
+                    className="underline hover:no-underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-gray-900 focus-visible:outline-offset-2"
+                    aria-label={`فتح صفحة المكان ${displayName(p)}`}
+                    title="فتح صفحة المكان"
+                  >
+                    فتح صفحة المكان →
+                  </a>
+                  <button
+                    type="button"
+                    className="underline hover:no-underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-gray-900 focus-visible:outline-offset-2"
+                    onClick={() => setFocusId(p.id)}
+                    aria-label={`فتح الخريطة مركّزة على ${displayName(p)}`}
+                    title="فتح الخريطة مركّزة على هذا المكان"
+                  >
+                    فتح على الخريطة
+                  </button>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      </section>
 
       <div aria-live="polite" className="sr-only">
-        {liveAnnouncement}
+        {focusAnnouncement}
       </div>
     </>
   );

--- a/tests/e2e/map.focus.spec.ts
+++ b/tests/e2e/map.focus.spec.ts
@@ -12,20 +12,35 @@ test('map focuses on requested place and copies link', async ({ page }) => {
   });
 
   await page.goto(canonicalMapUrl);
-  await expect(
-    page.locator('span.text-sm.text-gray-600', { hasText: 'Focused: Gaza' })
-  ).toBeVisible();
+  await expect(page.getByText('Focused: Gaza')).toBeVisible();
 
-  await page.getByRole('button', { name: 'Copy a shareable link to this view' }).click();
-  await expect(page.locator('span.text-green-600', { hasText: 'Link copied' })).toBeVisible();
+  await page.getByRole('button', { name: 'Copy link' }).click();
+  await expect(page.getByText('Link copied to clipboard')).toBeVisible();
 });
 
-test('open on map button focuses immediately', async ({ page }) => {
+test('list view supports keyboard navigation to focus places', async ({ page }) => {
   await page.goto('/map');
-  const jaffaButton = page.getByRole('button', { name: 'Open map focused on Jaffa' });
-  await jaffaButton.click();
-  await expect(page).toHaveURL(/\/map\?place=jaffa/);
-  await expect(
-    page.locator('span.text-sm.text-gray-600', { hasText: 'Focused: Jaffa' })
-  ).toBeVisible();
+  await page.getByRole('button', { name: 'List view' }).click();
+
+  const list = page.getByRole('list', { name: 'Places list' });
+  await expect(list).toBeVisible();
+  await expect(list).toBeFocused();
+
+  await page.keyboard.press('Tab');
+  const firstPlaceButton = list.locator('li button').first();
+  await expect(firstPlaceButton).toBeFocused();
+
+  const initialUrl = page.url();
+  await page.keyboard.press('Enter');
+  await expect(page).not.toHaveURL(initialUrl);
+  await expect(page).toHaveURL(/place=/);
+});
+
+test('focus map control directs focus to the leaflet container', async ({ page }) => {
+  await page.goto('/map');
+  const mapContainer = page.locator('.leaflet-container').first();
+  await expect(mapContainer).toBeVisible();
+
+  await page.getByRole('button', { name: 'Focus map' }).click();
+  await expect(mapContainer).toBeFocused();
 });


### PR DESCRIPTION
## Summary
- add per-page skip links and wrap the map experience in a shared announcer provider
- refactor map clients to toggle between map and list views, expose focus controls, and label Leaflet controls
- replace inline copy affordance with a toast announcer and expand Playwright coverage for list navigation and copy feedback

## Testing
- npx playwright test tests/e2e/map.focus.spec.ts *(fails: requires Next.js production build)*

------
https://chatgpt.com/codex/tasks/task_b_690c373c9ce4832ebefc9fc58370f766