### PR TITLE
Localize timeline numerals for Arabic readers

### DIFF
--- a/components/Footnotes.tsx
+++ b/components/Footnotes.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 
+import { formatNumber } from '@/lib/format';
+
 type FootnoteEntry = {
   index: number;
   noteId: string;
@@ -10,15 +12,10 @@ type FootnoteEntry = {
 
 type Locale = 'en' | 'ar';
 
-function numberFormatter(locale: Locale) {
-  return new Intl.NumberFormat(locale === 'ar' ? 'ar' : 'en');
-}
-
 export function createFootnotesManager(locale: Locale = 'en') {
   let counter = 0;
   const notes: FootnoteEntry[] = [];
 
-  const formatter = numberFormatter(locale);
   const heading = locale === 'ar' ? 'حواشي' : 'Footnotes';
   const backLabel = locale === 'ar' ? 'عودة إلى النص' : 'Back to text';
   const footnoteLabel = (value: string) =>
@@ -36,7 +33,7 @@ export function createFootnotesManager(locale: Locale = 'en') {
   function Footnote({ children }: { children: React.ReactNode }) {
     counter += 1;
     const index = counter;
-    const displayNumber = formatter.format(index);
+    const displayNumber = formatNumber(index, locale);
     const noteId = `footnote-${index}`;
     const refId = `footnote-ref-${index}`;
 

--- a/components/MapsPageClient.ar.tsx
+++ b/components/MapsPageClient.ar.tsx
@@ -4,6 +4,8 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useId } from 'react';
 import dynamic from 'next/dynamic';
 
+import { formatNumber } from '@/lib/format';
+
 import { useAnnouncer } from './Announcer';
 
 // Load MapClient only on the client so SSR never touches Leaflet/window.
@@ -113,7 +115,8 @@ export default function MapsPageClientAr({
   const mapStatus = useMemo(() => {
     const total = places.length;
     const modeLabel = mode === 'map' ? 'عرض الخريطة' : 'عرض القائمة';
-    return `${modeLabel}. عرض ${total} مكانًا.`;
+    const totalLabel = formatNumber(total, 'ar');
+    return `${modeLabel}. عرض ${totalLabel} مكانًا.`;
   }, [mode, places.length]);
 
   const handleShowMap = useCallback(() => {
@@ -293,7 +296,16 @@ export default function MapsPageClientAr({
                 >
                   <div className="font-medium">{displayName(p)}</div>
                   <div className="text-sm text-gray-700">
-                    {formatKindAr(p.kind)} · {p.lat.toFixed(3)}, {p.lon.toFixed(3)}
+                    {formatKindAr(p.kind)} ·{' '}
+                    {formatNumber(p.lat, 'ar', {
+                      minimumFractionDigits: 3,
+                      maximumFractionDigits: 3,
+                    })}
+                    {'، '}
+                    {formatNumber(p.lon, 'ar', {
+                      minimumFractionDigits: 3,
+                      maximumFractionDigits: 3,
+                    })}
                   </div>
                   {p.alt_names?.length ? (
                     <div className="text-xs text-gray-700 mt-1">

--- a/components/SearchClient.tsx
+++ b/components/SearchClient.tsx
@@ -11,6 +11,7 @@ import React, {
 } from 'react';
 
 import LocaleLink from '@/components/LocaleLink';
+import { formatNumber } from '@/lib/format';
 import {
   composeSearchFilterAnnouncement,
   composeSearchQueryAnnouncement,
@@ -46,7 +47,8 @@ export default function SearchClient({ locale = 'en' }: Props) {
         loading: 'جاري تحميل الفهرس…',
         error: 'تعذّر تحميل الفهرس. حاول مجددًا.',
         empty: 'لا توجد نتائج مطابقة.',
-        count: (n: number) => (n === 1 ? 'نتيجة واحدة' : `${n} من النتائج`),
+        count: (n: number) =>
+          n === 1 ? 'نتيجة واحدة' : `${formatNumber(n, 'ar')} من النتائج`,
         typeLabels: {
           chapter: 'فصل',
           event: 'حدث',
@@ -74,7 +76,7 @@ export default function SearchClient({ locale = 'en' }: Props) {
       loading: 'Loading search index…',
       error: 'Unable to load the search index. Please try again.',
       empty: 'No matching results yet.',
-      count: (n: number) => (n === 1 ? '1 result' : `${n} results`),
+      count: (n: number) => (n === 1 ? '1 result' : `${formatNumber(n, 'en')} results`),
       typeLabels: {
         chapter: 'Chapter',
         event: 'Timeline event',

--- a/components/Timeline.tsx
+++ b/components/Timeline.tsx
@@ -1,17 +1,6 @@
 import LocaleLink from '@/components/LocaleLink';
-import { formatNumber } from '@/lib/format';
+import { formatYear } from '@/lib/format';
 import type { TimelineEvent, Era } from '@/lib/types';
-
-function formatYear(value: number | null | undefined, locale: 'en' | 'ar'): string {
-  if (value === null || typeof value === 'undefined') {
-    return '';
-  }
-  if (value < 0) {
-    const digits = formatNumber(Math.abs(value), locale);
-    return locale === 'ar' ? `${digits} ق.م.` : `${digits} BCE`;
-  }
-  return formatNumber(value, locale);
-}
 
 export default function Timeline({
   events,

--- a/components/Timeline.tsx
+++ b/components/Timeline.tsx
@@ -1,11 +1,16 @@
 import LocaleLink from '@/components/LocaleLink';
+import { formatNumber } from '@/lib/format';
 import type { TimelineEvent, Era } from '@/lib/types';
 
-function yearOf(d: string | number | undefined): string {
-  if (d === undefined || d === null) return '';
-  const s = String(d);
-  const m = s.match(/^(-?\d{1,4})/);
-  return m ? m[1] : s;
+function formatYear(value: number | null | undefined, locale: 'en' | 'ar'): string {
+  if (value === null || typeof value === 'undefined') {
+    return '';
+  }
+  if (value < 0) {
+    const digits = formatNumber(Math.abs(value), locale);
+    return locale === 'ar' ? `${digits} ق.م.` : `${digits} BCE`;
+  }
+  return formatNumber(value, locale);
 }
 
 export default function Timeline({
@@ -50,8 +55,8 @@ export default function Timeline({
           }
         >
           <div className="text-xs text-gray-700">
-            {e.era ? eraById.get(e.era) : '—'} · {yearOf(e.start)}
-            {e.end ? `–${yearOf(e.end)}` : ''}
+            {e.era ? eraById.get(e.era) : '—'} · {formatYear(e.start, locale)}
+            {typeof e.end === 'number' ? `–${formatYear(e.end, locale)}` : ''}
           </div>
           <h3 className="text-base font-semibold mt-1">{e.title}</h3>
           {e.summary && <p className="mt-1 text-sm">{e.summary}</p>}

--- a/components/TimelineEventDetail.tsx
+++ b/components/TimelineEventDetail.tsx
@@ -1,4 +1,5 @@
 import LocaleLink from '@/components/LocaleLink';
+import { formatNumber } from '@/lib/format';
 import { loadEras, getRelatedTimelineEvents } from '@/lib/loaders.timeline';
 import { loadGazetteer } from '@/lib/loaders.places';
 import type { TimelineEvent } from '@/lib/types';
@@ -8,10 +9,10 @@ function formatYear(value: number | null, locale: 'en' | 'ar'): string {
     return locale === 'ar' ? 'غير معروف' : 'Unknown';
   }
   if (value < 0) {
-    const year = Math.abs(value);
-    return locale === 'ar' ? `${year} ق.م.` : `${year} BCE`;
+    const digits = formatNumber(Math.abs(value), locale);
+    return locale === 'ar' ? `${digits} ق.م.` : `${digits} BCE`;
   }
-  return String(value);
+  return formatNumber(value, locale);
 }
 
 function formatRange(event: TimelineEvent, locale: 'en' | 'ar'): string {

--- a/components/TimelineEventDetail.tsx
+++ b/components/TimelineEventDetail.tsx
@@ -1,26 +1,16 @@
 import LocaleLink from '@/components/LocaleLink';
-import { formatNumber } from '@/lib/format';
+import { formatYear } from '@/lib/format';
 import { loadEras, getRelatedTimelineEvents } from '@/lib/loaders.timeline';
 import { loadGazetteer } from '@/lib/loaders.places';
 import type { TimelineEvent } from '@/lib/types';
 
-function formatYear(value: number | null, locale: 'en' | 'ar'): string {
-  if (value === null || typeof value === 'undefined') {
-    return locale === 'ar' ? 'غير معروف' : 'Unknown';
-  }
-  if (value < 0) {
-    const digits = formatNumber(Math.abs(value), locale);
-    return locale === 'ar' ? `${digits} ق.م.` : `${digits} BCE`;
-  }
-  return formatNumber(value, locale);
-}
-
 function formatRange(event: TimelineEvent, locale: 'en' | 'ar'): string {
-  const startLabel = formatYear(event.start, locale);
+  const unknownLabel = locale === 'ar' ? 'غير معروف' : 'Unknown';
+  const startLabel = formatYear(event.start, locale, { unknownLabel });
   if (event.end === null || typeof event.end === 'undefined') {
     return startLabel;
   }
-  const endLabel = formatYear(event.end, locale);
+  const endLabel = formatYear(event.end, locale, { unknownLabel });
   return `${startLabel}–${endLabel}`;
 }
 

--- a/components/TimelineFilters.tsx
+++ b/components/TimelineFilters.tsx
@@ -4,6 +4,7 @@ import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import type { Era } from '@/lib/types';
 import * as React from 'react';
 import A11yAnnouncer, { type A11yAnnouncerHandle } from '@/components/A11yAnnouncer';
+import { formatNumber } from '@/lib/format';
 import {
   composeBookmarkAnnouncement,
   composeTimelineChipAnnouncement,
@@ -47,8 +48,8 @@ type Translation = {
   copyError: string;
   appliedBookmark: (label: string) => string;
   deletedBookmark: (label: string) => string;
-  resultMessage: (count: number) => string;
-  resultMessageArabic: (count: number) => string;
+  resultMessage: (count: number, formatted: string) => string;
+  resultMessageArabic: (count: number, formatted: string) => string;
   filterStateSelected: string;
   filterStateNotSelected: string;
 };
@@ -78,8 +79,10 @@ const translations: Record<Locale, Translation> = {
     copyError: 'Unable to copy link. Copy it manually from the address bar.',
     appliedBookmark: (label) => `Applied filter set “${label}”`,
     deletedBookmark: (label) => `Deleted filter set “${label}”`,
-    resultMessage: (count) => (count === 1 ? 'Showing 1 event' : `Showing ${count} events`),
-    resultMessageArabic: (count) => (count === 1 ? 'تم العثور على حدث واحد' : `تم العثور على ${count} من الأحداث`),
+    resultMessage: (count, formatted) =>
+      count === 1 ? 'Showing 1 event' : `Showing ${formatted} events`,
+    resultMessageArabic: (count, formatted) =>
+      count === 1 ? 'تم العثور على حدث واحد' : `تم العثور على ${formatted} من الأحداث`,
     filterStateSelected: 'selected',
     filterStateNotSelected: 'not selected',
   },
@@ -107,8 +110,10 @@ const translations: Record<Locale, Translation> = {
     copyError: 'تعذّر نسخ الرابط. انسخه يدويًا من شريط العنوان.',
     appliedBookmark: (label) => `تم تطبيق مجموعة المرشحات «${label}»`,
     deletedBookmark: (label) => `تم حذف مجموعة المرشحات «${label}»`,
-    resultMessage: (count) => (count === 1 ? 'Showing 1 event' : `Showing ${count} events`),
-    resultMessageArabic: (count) => (count === 1 ? 'تم العثور على حدث واحد' : `تم العثور على ${count} من الأحداث`),
+    resultMessage: (count, formatted) =>
+      count === 1 ? 'Showing 1 event' : `Showing ${formatted} events`,
+    resultMessageArabic: (count, formatted) =>
+      count === 1 ? 'تم العثور على حدث واحد' : `تم العثور على ${formatted} من الأحداث`,
     filterStateSelected: 'محددة',
     filterStateNotSelected: 'غير محددة',
   },
@@ -116,7 +121,10 @@ const translations: Record<Locale, Translation> = {
 
 function formatResultMessage(count: number, locale: Locale): string {
   const t = translations[locale];
-  return locale === 'ar' ? t.resultMessageArabic(count) : t.resultMessage(count);
+  const formatted = formatNumber(count, locale);
+  return locale === 'ar'
+    ? t.resultMessageArabic(count, formatted)
+    : t.resultMessage(count, formatted);
 }
 
 function loadStoredBookmarks(): Bookmark[] {

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -1,0 +1,43 @@
+type NumberFormatOptions = Intl.NumberFormatOptions & { numberingSystem?: string };
+type DateFormatOptions = Intl.DateTimeFormatOptions & { numberingSystem?: string };
+
+const AR_NUMBERING_SYSTEM: NumberFormatOptions = { numberingSystem: 'arab' };
+
+function getNumberOptions(locale: string, options?: NumberFormatOptions): NumberFormatOptions {
+  const base = locale === 'ar' ? AR_NUMBERING_SYSTEM : {};
+  return { ...base, ...(options ?? {}) };
+}
+
+export function formatNumber(
+  value: number | bigint | string,
+  locale: string,
+  options?: NumberFormatOptions
+): string {
+  if (value === null || typeof value === 'undefined') return '';
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    if (Number.isNaN(parsed)) {
+      return value;
+    }
+    return new Intl.NumberFormat(locale, getNumberOptions(locale, options)).format(parsed);
+  }
+  if (typeof value === 'number' && !Number.isFinite(value)) {
+    return '';
+  }
+  return new Intl.NumberFormat(locale, getNumberOptions(locale, options)).format(value as number | bigint);
+}
+
+export function formatDate(
+  value: Date | string | number,
+  locale: string,
+  options?: DateFormatOptions
+): string {
+  if (value === null || typeof value === 'undefined') return '';
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return '';
+  const formatOptions: DateFormatOptions = {
+    ...(locale === 'ar' ? { numberingSystem: 'arab' } : {}),
+    ...(options ?? {}),
+  };
+  return new Intl.DateTimeFormat(locale, formatOptions).format(date);
+}

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -1,5 +1,8 @@
 type NumberFormatOptions = Intl.NumberFormatOptions & { numberingSystem?: string };
 type DateFormatOptions = Intl.DateTimeFormatOptions & { numberingSystem?: string };
+type FormatYearOptions = {
+  unknownLabel?: string;
+};
 
 const AR_NUMBERING_SYSTEM: NumberFormatOptions = { numberingSystem: 'arab' };
 
@@ -40,4 +43,19 @@ export function formatDate(
     ...(options ?? {}),
   };
   return new Intl.DateTimeFormat(locale, formatOptions).format(date);
+}
+
+export function formatYear(
+  value: number | null | undefined,
+  locale: 'en' | 'ar',
+  options?: FormatYearOptions
+): string {
+  if (value === null || typeof value === 'undefined') {
+    return options?.unknownLabel ?? '';
+  }
+  const digits = formatNumber(Math.abs(value), locale, { useGrouping: false });
+  if (value < 0) {
+    return locale === 'ar' ? `${digits} ق.م.` : `${digits} BCE`;
+  }
+  return digits;
 }

--- a/tests/e2e/timeline.details.spec.ts
+++ b/tests/e2e/timeline.details.spec.ts
@@ -7,3 +7,10 @@ test('timeline detail page renders event content', async ({ page }) => {
   await expect(page.getByRole('heading', { level: 2, name: 'Related timeline' })).toBeVisible();
   await expect(page.getByRole('link', { name: 'View Gaza on the map' })).toBeVisible();
 });
+
+test('arabic timeline detail renders localized numerals', async ({ page }) => {
+  await page.goto('/ar/timeline/oslo-accords-1993-1995');
+
+  await expect(page.getByRole('heading', { level: 1, name: 'Oslo Accords' })).toBeVisible();
+  await expect(page.getByText('١٩٩٣–١٩٩٥')).toBeVisible();
+});

--- a/tests/unit/format.test.ts
+++ b/tests/unit/format.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { formatDate, formatNumber } from '@/lib/format';
+import { formatDate, formatNumber, formatYear } from '@/lib/format';
 
 describe('format helpers', () => {
   it('uses Eastern Arabic numerals when formatting numbers for Arabic', () => {
@@ -14,5 +14,16 @@ describe('format helpers', () => {
 
     expect(english).toMatch(/2024/);
     expect(arabic).toMatch(/[٠-٩]/);
+  });
+
+  it('omits grouping separators when formatting years', () => {
+    expect(formatYear(1993, 'en')).toBe('1993');
+    expect(formatYear(1993, 'ar')).toBe('١٩٩٣');
+    expect(formatYear(-1993, 'ar')).toBe('١٩٩٣ ق.م.');
+  });
+
+  it('returns unknown label when provided for missing years', () => {
+    expect(formatYear(null, 'en', { unknownLabel: 'Unknown' })).toBe('Unknown');
+    expect(formatYear(undefined, 'ar', { unknownLabel: 'غير معروف' })).toBe('غير معروف');
   });
 });

--- a/tests/unit/format.test.ts
+++ b/tests/unit/format.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatDate, formatNumber } from '@/lib/format';
+
+describe('format helpers', () => {
+  it('uses Eastern Arabic numerals when formatting numbers for Arabic', () => {
+    expect(formatNumber(1234, 'ar')).toBe('١٬٢٣٤');
+  });
+
+  it('respects locale when formatting dates', () => {
+    const sampleDate = new Date(Date.UTC(2024, 0, 15, 0, 0, 0));
+    const english = formatDate(sampleDate, 'en', { timeZone: 'UTC' });
+    const arabic = formatDate(sampleDate, 'ar', { timeZone: 'UTC' });
+
+    expect(english).toMatch(/2024/);
+    expect(arabic).toMatch(/[٠-٩]/);
+  });
+});


### PR DESCRIPTION
## Summary
- add shared format helpers to normalize number and date presentation with Arabic numerals when needed
- update timeline, filters, footnotes, search, and Arabic map list to rely on the helpers for localized digits
- cover the helpers with unit tests and assert Arabic numeral rendering in the timeline Playwright suite

## Testing
- pnpm test:unit -- --runInBand tests/unit/format.test.ts

------
https://chatgpt.com/codex/tasks/task_b_690cc59d47c8832e96285e4e135c4a88