### PR TITLE
Harden bilingual SEO defaults with shared metadata hints

### DIFF
--- a/app/(site)/ar/layout.tsx
+++ b/app/(site)/ar/layout.tsx
@@ -1,10 +1,14 @@
 import '../../globals.css';
 import type { ReactNode } from 'react';
+import type { Metadata } from 'next';
 
 import { LocaleProvider } from '@/components/LocaleLink';
 import { interVariable, naskhVariable } from '@/app/ui/fonts';
 
-export const metadata = {
+const tileOrigin = process.env.NEXT_PUBLIC_TILE_ORIGIN ?? 'https://tile.openstreetmap.org';
+const siteName = 'Palestine — 4,000 Years of Memory';
+
+export const metadata: Metadata = {
   title: 'فلسطين',
   description: 'تاريخ عام وفني لفلسطين',
   openGraph: {
@@ -12,11 +16,16 @@ export const metadata = {
     description: 'تاريخ عام وفني لفلسطين',
     type: 'website',
     url: '/ar',
+    siteName,
   },
   twitter: {
     card: 'summary_large_image',
     title: 'فلسطين',
     description: 'تاريخ عام وفني لفلسطين',
+  },
+  alternates: {
+    canonical: '/ar',
+    languages: { en: '/', ar: '/ar', 'x-default': '/' },
   },
 };
 
@@ -27,6 +36,10 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       dir="rtl"
       className={[interVariable, naskhVariable].filter(Boolean).join(' ')}
     >
+      <head>
+        <link rel="preconnect" href={tileOrigin} />
+        <link rel="dns-prefetch" href={tileOrigin} />
+      </head>
       <body className="font-arabic bg-white text-gray-900">
         <LocaleProvider locale="ar">
           <a

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,32 +1,36 @@
 // app/layout.tsx
 import './globals.css';
 import type { ReactNode } from 'react';
+import type { Metadata } from 'next';
 import Script from 'next/script';
 
 import { LocaleProvider } from '@/components/LocaleLink';
 import { interVariable, naskhVariable } from '@/app/ui/fonts';
 
 const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://palestine-two.vercel.app';
+const tileOrigin = process.env.NEXT_PUBLIC_TILE_ORIGIN ?? 'https://tile.openstreetmap.org';
+const siteName = 'Palestine — 4,000 Years of Memory';
 
-export const metadata = {
+export const metadata: Metadata = {
   metadataBase: new URL(siteUrl),
-  title: 'Palestine — 4,000 Years of Memory',
+  title: siteName,
   description:
     'A bilingual, anti-colonial history of Palestine across 4,000 years — maps, timelines, sources, and chapters.',
   openGraph: {
-    title: 'Palestine — 4,000 Years of Memory',
+    title: siteName,
     description:
       'A bilingual, anti-colonial history of Palestine across 4,000 years — maps, timelines, sources, and chapters.',
     type: 'website',
+    siteName,
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Palestine — 4,000 Years of Memory',
+    title: siteName,
     description:
       'A bilingual, anti-colonial history of Palestine across 4,000 years — maps, timelines, sources, and chapters.',
   },
   alternates: {
-    languages: { ar: '/ar' },
+    languages: { en: '/', ar: '/ar', 'x-default': '/' },
   },
 };
 
@@ -37,6 +41,10 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       suppressHydrationWarning
       className={[interVariable, naskhVariable, 'no-js'].filter(Boolean).join(' ')}
     >
+      <head>
+        <link rel="preconnect" href={tileOrigin} />
+        <link rel="dns-prefetch" href={tileOrigin} />
+      </head>
       <body className="font-sans">
         <LocaleProvider locale="en">
           <Script id="init-js" strategy="beforeInteractive">

--- a/tests/e2e/seo.hreflang.spec.ts
+++ b/tests/e2e/seo.hreflang.spec.ts
@@ -6,6 +6,9 @@ type SeoExpectation = {
   alternates: Record<string, string>;
 };
 
+const siteName = 'Palestine — 4,000 Years of Memory';
+const tileOrigin = process.env.NEXT_PUBLIC_TILE_ORIGIN ?? 'https://tile.openstreetmap.org';
+
 const pages: SeoExpectation[] = [
   {
     path: '/',
@@ -72,6 +75,27 @@ test.describe('SEO metadata', () => {
       const canonicalUrl = new URL(canonicalHref ?? '', page.url());
       expect(canonicalUrl.pathname).toBe(expectedCanonical.pathname);
       expect(canonicalUrl.search).toBe(expectedCanonical.search);
+
+      await expect(
+        page.locator(`link[rel="preconnect"][href="${tileOrigin}"]`),
+      ).toHaveCount(1);
+      await expect(
+        page.locator(`link[rel="dns-prefetch"][href="${tileOrigin}"]`),
+      ).toHaveCount(1);
+
+      const ogType = await page
+        .locator('meta[property="og:type"]')
+        .first()
+        .getAttribute('content');
+      expect(ogType).toBe('website');
+
+      await expect(
+        page.locator('meta[property="og:site_name"]'),
+      ).toHaveAttribute('content', siteName);
+
+      await expect(
+        page.locator('meta[name="twitter:card"]'),
+      ).toHaveAttribute('content', 'summary_large_image');
 
       for (const [lang, href] of Object.entries(pageConfig.alternates)) {
         const alternateLocator = page.locator(


### PR DESCRIPTION
## Summary
- expand the root layout metadata to share the canonical site name, OG/Twitter defaults, hreflang pairs, and tile resource hints
- mirror the metadata and resource hints in the Arabic segment layout so localized routes inherit the same defaults
- extend the Playwright SEO coverage to assert the resource hints and OG/Twitter defaults across both locales

## Testing
- pnpm build
- pnpm playwright test tests/e2e/seo.hreflang.spec.ts *(fails: Chromium browser binaries cannot be downloaded in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_b_690cce98c944832ea5b35a1ffbabd716