### PR TITLE
Create shared skip link component with locale detection

### DIFF
--- a/app/(site)/ar/layout.tsx
+++ b/app/(site)/ar/layout.tsx
@@ -2,7 +2,6 @@ import '../../globals.css';
 import type { ReactNode } from 'react';
 import type { Metadata } from 'next';
 
-import { LocaleProvider } from '@/components/LocaleLink';
 import { interVariable, naskhVariable } from '@/app/ui/fonts';
 
 const tileOrigin = process.env.NEXT_PUBLIC_TILE_ORIGIN ?? 'https://tile.openstreetmap.org';
@@ -41,15 +40,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         <link rel="dns-prefetch" href={tileOrigin} />
       </head>
       <body className="font-arabic bg-white text-gray-900">
-        <LocaleProvider locale="ar">
-          <a
-            href="#main"
-            className="sr-only focus:not-sr-only focus:absolute rtl:focus:right-3 ltr:focus:left-3 focus:top-3 focus:z-50 rounded bg-white px-3 py-1 text-sm shadow"
-          >
-            تجاوز إلى المحتوى
-          </a>
-          <div>{children}</div>
-        </LocaleProvider>
+        <div>{children}</div>
       </body>
     </html>
   );

--- a/app/(site)/ar/layout.tsx
+++ b/app/(site)/ar/layout.tsx
@@ -1,10 +1,9 @@
-import '../../globals.css';
 import type { ReactNode } from 'react';
+import { Suspense } from 'react';
 import type { Metadata } from 'next';
 
-import { interVariable, naskhVariable } from '@/app/ui/fonts';
+import LanguageSwitcher from '@/components/LanguageSwitcher';
 
-const tileOrigin = process.env.NEXT_PUBLIC_TILE_ORIGIN ?? 'https://tile.openstreetmap.org';
 const siteName = 'Palestine — 4,000 Years of Memory';
 
 export const metadata: Metadata = {
@@ -28,20 +27,22 @@ export const metadata: Metadata = {
   },
 };
 
-export default function RootLayout({ children }: { children: ReactNode }) {
+export default function ArabicSiteSegmentLayout({ children }: { children: ReactNode }) {
   return (
-    <html
-      lang="ar"
+    <div
+      data-locale="ar"
       dir="rtl"
-      className={[interVariable, naskhVariable].filter(Boolean).join(' ')}
+      lang="ar"
+      className="min-h-screen bg-white text-gray-900 font-arabic"
     >
-      <head>
-        <link rel="preconnect" href={tileOrigin} />
-        <link rel="dns-prefetch" href={tileOrigin} />
-      </head>
-      <body className="font-arabic bg-white text-gray-900">
-        <div>{children}</div>
-      </body>
-    </html>
+      <header className="border-b">
+        <div className="mx-auto flex max-w-4xl justify-end rtl:justify-start px-4 py-3">
+          <Suspense fallback={<span className="text-sm text-gray-400 font-arabic">…</span>}>
+            <LanguageSwitcher />
+          </Suspense>
+        </div>
+      </header>
+      <div>{children}</div>
+    </div>
   );
 }

--- a/app/(site)/layout.tsx
+++ b/app/(site)/layout.tsx
@@ -9,7 +9,7 @@ import LanguageSwitcher from '@/components/LanguageSwitcher';
  */
 export default function SiteSegmentLayout({ children }: { children: ReactNode }) {
   return (
-    <div className="min-h-screen bg-white text-gray-900">
+    <div data-locale="en" className="min-h-screen bg-white text-gray-900">
       <header className="border-b">
         <div className="mx-auto flex max-w-4xl justify-end rtl:justify-start px-4 py-3">
           <Suspense fallback={<span className="text-sm text-gray-400">…</span>}>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,9 +1,8 @@
 // app/layout.tsx
 import './globals.css';
-import type { ReactNode } from 'react';
+import { isValidElement, type ReactNode } from 'react';
 import type { Metadata } from 'next';
 import Script from 'next/script';
-import { headers } from 'next/headers';
 
 import { LocaleProvider, type Locale } from '@/components/LocaleLink';
 import SkipLink from '@/components/SkipLink';
@@ -36,57 +35,76 @@ export const metadata: Metadata = {
   },
 };
 
-function extractPath(candidate: string | null): string | null {
-  if (!candidate) return null;
-  const trimmed = candidate.trim();
-  if (!trimmed) return null;
-
-  if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) {
-    try {
-      const url = new URL(trimmed);
-      return url.pathname || '/';
-    } catch {
-      return null;
-    }
+function normaliseLocale(value: unknown): Locale | null {
+  if (typeof value !== 'string') {
+    return null;
   }
+  const trimmed = value.trim().toLowerCase();
+  if (trimmed === 'en' || trimmed === 'ar') {
+    return trimmed as Locale;
+  }
+  return null;
+}
 
-  if (!trimmed.startsWith('/')) {
+function findLocale(node: ReactNode): Locale | null {
+  if (node == null || typeof node === 'boolean') {
     return null;
   }
 
-  const [path] = trimmed.split(/[?#]/, 1);
-  return path && path.length > 0 ? path : '/';
-}
-
-function detectLocaleFromPath(pathname: string): Locale {
-  if (pathname === '/ar' || pathname.startsWith('/ar/')) {
-    return 'ar';
+  if (typeof node === 'string' || typeof node === 'number') {
+    return null;
   }
-  return 'en';
-}
 
-function determineLocale(): Locale {
-  const headerList = headers();
-  const headerKeys = ['x-pathname', 'x-next-pathname', 'x-invoke-path', 'x-matched-path', 'next-url'] as const;
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      const matched = findLocale(child);
+      if (matched) {
+        return matched;
+      }
+    }
+    return null;
+  }
 
-  for (const key of headerKeys) {
-    const value = headerList.get(key);
-    const path = extractPath(value);
-    if (path) {
-      return detectLocaleFromPath(path);
+  if (isValidElement(node)) {
+    const props = node.props as Record<string, unknown> | undefined;
+    if (props) {
+      const directMatch =
+        normaliseLocale(props['data-locale']) ??
+        normaliseLocale(props.locale) ??
+        normaliseLocale(props.lang);
+      if (directMatch) {
+        return directMatch;
+      }
+
+      const childMatch = findLocale(props.children as ReactNode);
+      if (childMatch) {
+        return childMatch;
+      }
+
+      for (const [key, value] of Object.entries(props)) {
+        if (key === 'children') {
+          continue;
+        }
+        if (typeof value === 'function') {
+          continue;
+        }
+        const nestedMatch = findLocale(value as ReactNode);
+        if (nestedMatch) {
+          return nestedMatch;
+        }
+      }
     }
   }
 
-  const refererPath = extractPath(headerList.get('referer'));
-  if (refererPath) {
-    return detectLocaleFromPath(refererPath);
-  }
+  return null;
+}
 
-  return 'en';
+function determineLocale(children: ReactNode): Locale {
+  return findLocale(children) ?? 'en';
 }
 
 export default function RootLayout({ children }: { children: ReactNode }) {
-  const locale = determineLocale();
+  const locale = determineLocale(children);
   const isArabic = locale === 'ar';
   const htmlLang = isArabic ? 'ar' : 'en';
   const direction = isArabic ? 'rtl' : 'ltr';

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,8 +3,10 @@ import './globals.css';
 import type { ReactNode } from 'react';
 import type { Metadata } from 'next';
 import Script from 'next/script';
+import { headers } from 'next/headers';
 
-import { LocaleProvider } from '@/components/LocaleLink';
+import { LocaleProvider, type Locale } from '@/components/LocaleLink';
+import SkipLink from '@/components/SkipLink';
 import { interVariable, naskhVariable } from '@/app/ui/fonts';
 
 const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://palestine-two.vercel.app';
@@ -34,10 +36,66 @@ export const metadata: Metadata = {
   },
 };
 
+function extractPath(candidate: string | null): string | null {
+  if (!candidate) return null;
+  const trimmed = candidate.trim();
+  if (!trimmed) return null;
+
+  if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) {
+    try {
+      const url = new URL(trimmed);
+      return url.pathname || '/';
+    } catch {
+      return null;
+    }
+  }
+
+  if (!trimmed.startsWith('/')) {
+    return null;
+  }
+
+  const [path] = trimmed.split(/[?#]/, 1);
+  return path && path.length > 0 ? path : '/';
+}
+
+function detectLocaleFromPath(pathname: string): Locale {
+  if (pathname === '/ar' || pathname.startsWith('/ar/')) {
+    return 'ar';
+  }
+  return 'en';
+}
+
+function determineLocale(): Locale {
+  const headerList = headers();
+  const headerKeys = ['x-pathname', 'x-next-pathname', 'x-invoke-path', 'x-matched-path', 'next-url'] as const;
+
+  for (const key of headerKeys) {
+    const value = headerList.get(key);
+    const path = extractPath(value);
+    if (path) {
+      return detectLocaleFromPath(path);
+    }
+  }
+
+  const refererPath = extractPath(headerList.get('referer'));
+  if (refererPath) {
+    return detectLocaleFromPath(refererPath);
+  }
+
+  return 'en';
+}
+
 export default function RootLayout({ children }: { children: ReactNode }) {
+  const locale = determineLocale();
+  const isArabic = locale === 'ar';
+  const htmlLang = isArabic ? 'ar' : 'en';
+  const direction = isArabic ? 'rtl' : 'ltr';
+  const bodyClassName = isArabic ? 'font-arabic bg-white text-gray-900' : 'font-sans';
+
   return (
     <html
-      lang="en"
+      lang={htmlLang}
+      dir={direction}
       suppressHydrationWarning
       className={[interVariable, naskhVariable, 'no-js'].filter(Boolean).join(' ')}
     >
@@ -45,18 +103,13 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         <link rel="preconnect" href={tileOrigin} />
         <link rel="dns-prefetch" href={tileOrigin} />
       </head>
-      <body className="font-sans">
-        <LocaleProvider locale="en">
+      <body className={bodyClassName}>
+        <LocaleProvider locale={locale}>
           <Script id="init-js" strategy="beforeInteractive">
             {`document.documentElement.classList.remove('no-js');
 document.documentElement.classList.add('js-enabled');`}
           </Script>
-          <a
-            href="#main"
-            className="sr-only focus:not-sr-only focus:absolute focus:left-3 focus:top-3 focus:z-50 rounded bg-white px-3 py-1 text-sm shadow"
-          >
-            Skip to main content
-          </a>
+          <SkipLink locale={locale} />
           {children}
         </LocaleProvider>
       </body>

--- a/components/SkipLink.tsx
+++ b/components/SkipLink.tsx
@@ -1,0 +1,23 @@
+import type { Locale } from '@/components/LocaleLink';
+
+const labels: Record<Locale, string> = {
+  en: 'Skip to main content',
+  ar: 'تجاوز إلى المحتوى',
+};
+
+const baseClasses =
+  'sr-only focus:not-sr-only focus:absolute focus:top-3 focus:z-50 rounded bg-white px-3 py-1 text-sm shadow';
+const directionalClasses = 'ltr:focus:left-3 rtl:focus:right-3';
+
+type SkipLinkProps = {
+  locale: Locale;
+};
+
+export default function SkipLink({ locale }: SkipLinkProps) {
+  const label = labels[locale] ?? labels.en;
+  return (
+    <a href="#main" className={`${baseClasses} ${directionalClasses}`}>
+      {label}
+    </a>
+  );
+}


### PR DESCRIPTION
## Summary
- add a shared `SkipLink` component that localizes the skip-navigation anchor
- detect the active locale in the root layout so the skip link and `LocaleProvider` use the right language
- drop the duplicated skip link/provider from the Arabic segment layout to avoid rendering two anchors

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_690cebde39f4832ea0145227d6954cb2