### PR TITLE
Improve root locale handling for app shell

### DIFF
--- a/app/(site)/ar/layout.tsx
+++ b/app/(site)/ar/layout.tsx
@@ -29,7 +29,12 @@ export const metadata: Metadata = {
 
 export default function ArabicSiteSegmentLayout({ children }: { children: ReactNode }) {
   return (
-    <div className="min-h-screen bg-white text-gray-900 font-arabic" data-locale="ar">
+    <div
+      className="min-h-screen bg-white text-gray-900 font-arabic"
+      data-locale="ar"
+      dir="rtl"
+      lang="ar"
+    >
       <header className="border-b">
         <div className="mx-auto flex max-w-4xl justify-end rtl:justify-start px-4 py-3">
           <Suspense fallback={<span className="text-sm text-gray-400 font-arabic">…</span>}>

--- a/app/(site)/ar/layout.tsx
+++ b/app/(site)/ar/layout.tsx
@@ -29,7 +29,7 @@ export const metadata: Metadata = {
 
 export default function ArabicSiteSegmentLayout({ children }: { children: ReactNode }) {
   return (
-    <div className="min-h-screen bg-white text-gray-900 font-arabic">
+    <div className="min-h-screen bg-white text-gray-900 font-arabic" data-locale="ar">
       <header className="border-b">
         <div className="mx-auto flex max-w-4xl justify-end rtl:justify-start px-4 py-3">
           <Suspense fallback={<span className="text-sm text-gray-400 font-arabic">…</span>}>

--- a/app/(site)/ar/layout.tsx
+++ b/app/(site)/ar/layout.tsx
@@ -29,12 +29,7 @@ export const metadata: Metadata = {
 
 export default function ArabicSiteSegmentLayout({ children }: { children: ReactNode }) {
   return (
-    <div
-      data-locale="ar"
-      dir="rtl"
-      lang="ar"
-      className="min-h-screen bg-white text-gray-900 font-arabic"
-    >
+    <div className="min-h-screen bg-white text-gray-900 font-arabic">
       <header className="border-b">
         <div className="mx-auto flex max-w-4xl justify-end rtl:justify-start px-4 py-3">
           <Suspense fallback={<span className="text-sm text-gray-400 font-arabic">…</span>}>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import type { Metadata } from 'next';
 import Script from 'next/script';
 import { headers } from 'next/headers';
 
+import DocumentLocaleUpdater from '@/components/DocumentLocaleUpdater';
 import { LocaleProvider, type Locale } from '@/components/LocaleLink';
 import SkipLink from '@/components/SkipLink';
 import { interVariable, naskhVariable } from '@/app/ui/fonts';
@@ -194,6 +195,7 @@ export default async function RootLayout({
     <html
       lang={htmlLang}
       dir={direction}
+      data-locale={locale}
       suppressHydrationWarning
       className={[interVariable, naskhVariable, 'no-js'].filter(Boolean).join(' ')}
     >
@@ -201,8 +203,9 @@ export default async function RootLayout({
         <link rel="preconnect" href={tileOrigin} />
         <link rel="dns-prefetch" href={tileOrigin} />
       </head>
-      <body className={bodyClassName}>
+      <body className={bodyClassName} dir={direction} lang={htmlLang} data-locale={locale}>
         <LocaleProvider locale={locale}>
+          <DocumentLocaleUpdater />
           <Script id="init-js" strategy="beforeInteractive">
             {`document.documentElement.classList.remove('no-js');
 document.documentElement.classList.add('js-enabled');`}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -170,14 +170,14 @@ function resolveLocale(
   );
 }
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
   params = {},
 }: {
   children: ReactNode;
-  params?: Record<string, string | string[]>;
+  params?: Record<string, string | string[] | undefined>;
 }) {
-  const headerList = headers();
+  const headerList = await headers();
   const inferredPathname =
     headerList.get('x-matched-path') ??
     headerList.get('x-invoke-path') ??

--- a/components/DocumentLocaleUpdater.tsx
+++ b/components/DocumentLocaleUpdater.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useEffect } from 'react';
+
+import { useLocale } from '@/components/LocaleLink';
+
+const ARABIC_BODY_CLASSES = ['font-arabic', 'bg-white', 'text-gray-900'] as const;
+const ENGLISH_BODY_CLASSES = ['font-sans'] as const;
+
+export default function DocumentLocaleUpdater(): null {
+  const locale = useLocale();
+
+  useEffect(() => {
+    const html = document.documentElement;
+    const body = document.body;
+    const isArabic = locale === 'ar';
+
+    html.lang = isArabic ? 'ar' : 'en';
+    html.dir = isArabic ? 'rtl' : 'ltr';
+    html.dataset.locale = locale;
+
+    body.lang = html.lang;
+    body.dir = html.dir;
+    body.dataset.locale = locale;
+
+    for (const className of ARABIC_BODY_CLASSES) {
+      body.classList.toggle(className, isArabic);
+    }
+
+    for (const className of ENGLISH_BODY_CLASSES) {
+      body.classList.toggle(className, !isArabic);
+    }
+  }, [locale]);
+
+  return null;
+}

--- a/components/LocaleLink.tsx
+++ b/components/LocaleLink.tsx
@@ -17,6 +17,10 @@ export function LocaleProvider({ locale, children }: PropsWithChildren<{ locale:
   return <LocaleContext.Provider value={locale}>{children}</LocaleContext.Provider>;
 }
 
+export function useLocale(): Locale {
+  return useContext(LocaleContext);
+}
+
 function isRelativeHref(href: string): boolean {
   if (!href) return false;
   const trimmed = href.trim();


### PR DESCRIPTION
## Summary
- read the active locale from route params or the matched pathname so the root layout sets `<html lang>`/`dir` directly
- normalize locale detection helpers and retain a tree-based fallback for safety
- simplify the Arabic site segment layout now that the root layout owns the document attributes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_690cf49d00ec832ea9b43c1f00f32724